### PR TITLE
fix: Only allow to enable repositories with admin privileges

### DIFF
--- a/tests/zeus/api/resources/test_github_repositories.py
+++ b/tests/zeus/api/resources/test_github_repositories.py
@@ -6,12 +6,18 @@ REPO_DETAILS_RESPONSE = """{
     "id": 1,
     "full_name": "getsentry/zeus",
     "clone_url": "https://github.com/getsentry/zeus.git",
-    "ssh_url": "git@github.com:getsentry/zeus.git"
+    "ssh_url": "git@github.com:getsentry/zeus.git",
+    "permissions": {
+        "admin": true
+    }
 }"""
 
 REPO_LIST_RESPONSE = """[{
     "id": 1,
-    "full_name": "getsentry/zeus"
+    "full_name": "getsentry/zeus",
+    "permissions": {
+        "admin": true
+    }
 }]"""
 
 KEY_RESPONSE = """{

--- a/tests/zeus/web/test_auth_github.py
+++ b/tests/zeus/web/test_auth_github.py
@@ -186,7 +186,10 @@ def test_login_complete_automatic_repo_access(client, mocker, db_session, respon
             'id': default_repo.external_id,
             'full_name': default_repo.data['full_name'],
             'clone_url': 'https://github.com/{}.git'.format(default_repo.data['full_name']),
-            'ssh_url': 'git@github.com:getsentry/zeus.git'
+            'ssh_url': 'git@github.com:getsentry/zeus.git',
+            'permissions': {
+                'admin': True
+            }
         },
     )
 

--- a/webapp/components/Button.jsx
+++ b/webapp/components/Button.jsx
@@ -55,8 +55,7 @@ export default styled.a`
   ${props =>
     props.disabled &&
     `
-      color: #ccc !important;
       cursor: default;
-      border-color: #ccc;
+      opacity: 0.3;
     `};
 `;

--- a/webapp/components/Button.jsx
+++ b/webapp/components/Button.jsx
@@ -51,4 +51,12 @@ export default styled.a`
         `;
     }
   }};
+
+  ${props =>
+    props.disabled &&
+    `
+      color: #ccc !important;
+      cursor: default;
+      border-color: #ccc;
+    `};
 `;

--- a/webapp/pages/GitHubRepositoryList.jsx
+++ b/webapp/pages/GitHubRepositoryList.jsx
@@ -129,18 +129,16 @@ class GitHubRepositoryList extends AsyncPage {
               this.props.removeRepo(repo);
             }
             this.props.removeIndicator(indicator);
-            this.setState({
-              ghRepoList: newGhRepoList
-            });
+            this.setState({ghRepoList: newGhRepoList});
           })
           .catch(error => {
             this.props.addIndicator('An error occurred.', 'error', 5000);
             this.props.removeIndicator(indicator);
 
-            let newGhRepo = (this.state.ghRepoList || []).find(
-              r => r.name === ghRepo.name
-            );
+            let newGhRepoList = [...this.state.ghRepoList];
+            let newGhRepo = newGhRepoList.find(r => r.name === ghRepo.name);
             newGhRepo.loading = false;
+            this.setState({ghRepoList: newGhRepoList});
 
             throw error;
           });

--- a/webapp/pages/GitHubRepositoryList.jsx
+++ b/webapp/pages/GitHubRepositoryList.jsx
@@ -28,6 +28,14 @@ class GitHubRepoItem extends Component {
   renderButton() {
     let {repo} = this.props;
 
+    if (repo.loading) {
+      return (
+        <Button disabled size="small">
+          ...
+        </Button>
+      );
+    }
+
     let props = repo.admin || {
       disabled: true,
       onClick: null,
@@ -55,7 +63,7 @@ class GitHubRepoItem extends Component {
       <Row>
         <Column>{repo.name}</Column>
         <Column textAlign="right" width={80}>
-          {repo.loading ? '...' : this.renderButton()}
+          {this.renderButton()}
         </Column>
       </Row>
     );

--- a/webapp/pages/GitHubRepositoryList.jsx
+++ b/webapp/pages/GitHubRepositoryList.jsx
@@ -28,27 +28,22 @@ class GitHubRepoItem extends Component {
   renderButton() {
     let {repo} = this.props;
 
+    let props = repo.admin || {
+      disabled: true,
+      onClick: null,
+      title: 'You need administrator privileges to activate this repository'
+    };
+
     if (repo.active) {
       return (
-        <Button onClick={this.props.onDisableRepo} size="small" type="danger">
+        <Button onClick={this.props.onDisableRepo} size="small" type="danger" {...props}>
           Disable
         </Button>
       );
     }
 
-    if (repo.admin) {
-      return (
-        <Button onClick={this.props.onEnableRepo} size="small">
-          Enable
-        </Button>
-      );
-    }
-
     return (
-      <Button
-        disabled
-        size="small"
-        title="You need administrator privileges to activate this repository">
+      <Button onClick={this.props.onEnableRepo} size="small" {...props}>
         Enable
       </Button>
     );

--- a/zeus/api/resources/github_repositories.py
+++ b/zeus/api/resources/github_repositories.py
@@ -55,6 +55,7 @@ class GitHubRepositoriesResource(Resource):
         return [
             {
                 'name': r['name'],
+                'admin': r['admin'],
                 'active': str(r['id']) in active_repo_ids,
             } for r in repo_list
         ]
@@ -94,6 +95,11 @@ class GitHubRepositoriesResource(Resource):
                     'url': exc.get_upgrade_url(),
                 }, 401
             )
+
+        if not repo_data['admin']:
+            return self.respond({
+                'message': 'Insufficient permissions to activate repository',
+            }, 403)
 
         lock_key = 'repo:{provider}/{owner_name}/{repo_name}'.format(
             provider='github',

--- a/zeus/api/schemas/repository.py
+++ b/zeus/api/schemas/repository.py
@@ -12,6 +12,7 @@ class RepositorySchema(Schema):
     url = fields.Str()
     provider = fields.Str()
     backend = EnumField(RepositoryBackend)
+    admin = fields.Bool()
     created_at = fields.DateTime(
         attribute='date_created',
         dump_only=True,

--- a/zeus/api/schemas/repository.py
+++ b/zeus/api/schemas/repository.py
@@ -12,7 +12,6 @@ class RepositorySchema(Schema):
     url = fields.Str()
     provider = fields.Str()
     backend = EnumField(RepositoryBackend)
-    admin = fields.Bool()
     created_at = fields.DateTime(
         attribute='date_created',
         dump_only=True,

--- a/zeus/vcs/providers/github.py
+++ b/zeus/vcs/providers/github.py
@@ -113,7 +113,7 @@ class GitHubCache(object):
             self.client = client
 
     def get_repos(self, owner, no_cache=False):
-        cache_key = 'gh:2:repos:{}:{}:{}'.format(
+        cache_key = 'gh:3:repos:{}:{}:{}'.format(
             md5(self.client.token.encode('utf')).hexdigest(),
             md5(b','.join(s.encode('utf') for s in self.scopes)).hexdigest(),
             md5(owner.encode('utf-8')).hexdigest() if owner else '',

--- a/zeus/vcs/providers/github.py
+++ b/zeus/vcs/providers/github.py
@@ -54,6 +54,7 @@ class GitHubRepositoryProvider(RepositoryProvider):
             {
                 'id': r['id'],
                 'name': r['full_name'],
+                'admin': r.get('admin', False),
             } for r in cache.get_repos(owner_name, no_cache=not self.cache)
         ]
 
@@ -76,6 +77,7 @@ class GitHubRepositoryProvider(RepositoryProvider):
             'owner_name': owner_name,
             'name': repo_name,
             'url': repo_data['ssh_url'],
+            'admin': repo_data['permissions'].get('admin', False),
             'config': {
                 'full_name': repo_data['full_name']
             }
@@ -136,6 +138,7 @@ class GitHubCache(object):
                 result.extend([{
                     'id': r['id'],
                     'full_name': r['full_name'],
+                    'admin': r['permissions'].get('admin', False),
                 } for r in response])
                 has_results = bool(response)
                 if has_results:


### PR DESCRIPTION
Zeus requires admin privileges on a repository to add deploy keys. If the user
does not have these, the server currently errors with 500. This is caused by
a 404 on the GitHub resource due to insufficient permissions.

This PR adds a check for admin privileges on each repository. In the UI all
buttons are disabled where admin privileges are missing. Also, the server
now fails more gracefully with an error message.

**NOTE:** The repo cache will not contain the flag. Please clear the cache
on deployment (key: `gh:2:repos:*`).

This should also "fix" [ZEUS-2X](https://sentry.io/sentry/zeus/issues/366310285/)