### PR TITLE
fix(github): Add public_repo to default GitHub permissions

### DIFF
--- a/tests/zeus/web/test_auth_github.py
+++ b/tests/zeus/web/test_auth_github.py
@@ -18,7 +18,7 @@ def test_login(client):
     assert qs['redirect_uri'] == ['http://localhost/auth/github/complete']
     assert qs['access_type'] == ['offline']
     assert qs['response_type'] == ['code']
-    assert sorted(qs['scope'][0].split(',')) == ['read:org', 'user:email']
+    assert sorted(qs['scope'][0].split(',')) == ['public_repo', 'read:org', 'user:email']
 
 
 def test_login_complete(client, db_session, mocker, responses):

--- a/zeus/web/__init__.py
+++ b/zeus/web/__init__.py
@@ -9,7 +9,9 @@ app = Blueprint('web', __name__)
 app.add_url_rule(
     '/auth/github',
     view_func=v.GitHubAuthView.as_view(
-        'github-auth', authorized_url='web.github-complete', scopes=('user:email', 'read:org')
+        'github-auth',
+        authorized_url='web.github-complete',
+        scopes=('user:email', 'read:org', 'public_repo')
     ),
 )
 app.add_url_rule(


### PR DESCRIPTION
Without `public_repo`, Zeus cannot access the "keys" resource which is
needed to add the deploy key on repo activation.

This went partially unnoticed, since we're usually always working with
elevated permissions to access private repositories. The `repo` permission
also includes access to settings of public repositories.

In addition to this, a user also needs admin access to the repository.
This is covered by #52. Together, they should fix
[ZEUS-2X](https://sentry.io/sentry/zeus/issues/366310285/).
