### PR TITLE
build: Use werkzeug master instead of pip latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,8 @@ RUN pip install -r requirements-dev.txt
 COPY requirements-test.txt /usr/src/zeus/
 RUN pip install -r requirements-test.txt
 
+RUN pip install -e git+https://github.com/pallets/werkzeug.git@8eb665a94aea9d9b56371663075818ca2546e152#egg=werkzeug
+
 COPY yarn.lock /usr/src/zeus/
 COPY package.json /usr/src/zeus/
 RUN yarn install --production --pure-lockfile --ignore-optional \

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ install-python-requirements:
 	pip install "pip>=9.0.0,<10.0.0"
 	pip install -e .
 	pip install "file://`pwd`#egg=zeus[tests]"
+	pip install -e git+https://github.com/pallets/werkzeug.git@8eb665a94aea9d9b56371663075818ca2546e152#egg=werkzeug
 
 install-js-requirements:
 	yarn install


### PR DESCRIPTION
This PR replaces the version of werkzeug required by flask with a commit that includes a fix for chunked transfer encoding. More information on this fix can be found at pallets/werkzeug#1198
It seems that the next release of werkzeug including this fix will not happen within the next month.

Chunked transfer encoding is required by the current version of `zeus-cli` to upload build artifacts.
