### PR TITLE
feat: Show aggregate test results on build details

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "object-assign": "4.1.1",
+    "percentile": "^1.2.0",
     "postcss-flexbugs-fixes": "3.0.0",
     "postcss-loader": "2.0.6",
     "prettier": "^1.5.2",

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -26,6 +26,7 @@ python-dateutil==2.6.1
 raven==6.1.0
 redis==2.10.5
 requests[security]==2.18.1
+SQLAlchemy==1.2.0
 toronado==0.0.11
 unidecode==0.04.21
 uwsgi==2.0.15

--- a/webapp/components/AggregateTestList.jsx
+++ b/webapp/components/AggregateTestList.jsx
@@ -1,0 +1,150 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {Flex, Box} from 'grid-styled';
+import styled from 'styled-components';
+
+import {Client} from '../api';
+
+import Collapsable from './Collapsable';
+import {AggregateDuration} from './ObjectDuration';
+import ObjectResult from './ObjectResult';
+import ResultGridRow from './ResultGridRow';
+import {ResultGrid, Column, Header} from './ResultGrid';
+
+class TestDetails extends Component {
+  static propTypes = {
+    test: PropTypes.object.isRequired
+  };
+
+  constructor(props, context) {
+    super(props, context);
+    this.state = {loading: true};
+  }
+
+  componentWillMount() {
+    this.api = new Client();
+  }
+
+  componentDidMount() {
+    let {test} = this.props;
+    this.api.request(`/tests/${test.id}`).then(testDetails => {
+      this.setState({loading: false, testDetails});
+    });
+  }
+
+  componentWillUnmount() {
+    this.api.clear();
+  }
+
+  // TODO(dcramer): make this more useful
+  render() {
+    if (this.state.loading) return <TestDetailsWrapper>(loading)</TestDetailsWrapper>;
+    let {testDetails} = this.state;
+    return (
+      <TestDetailsWrapper>
+        <h5>
+          <ObjectResult data={testDetails} /> on Job #{testDetails.job.number}
+          {testDetails.job.label &&
+            <span>
+              {' '}&mdash; {testDetails.job.label}
+            </span>}
+        </h5>
+        <pre style={{margin: 0}}>
+          {testDetails.message || <em>no output captured</em>}
+        </pre>
+      </TestDetailsWrapper>
+    );
+  }
+}
+
+class TestListItem extends Component {
+  static propTypes = {
+    test: PropTypes.object.isRequired
+  };
+
+  constructor(props, context) {
+    super(props, context);
+    this.state = {expanded: false};
+  }
+
+  render() {
+    let {params, test} = this.props;
+    return (
+      <TestListItemLink onClick={() => this.setState({expanded: !this.state.expanded})}>
+        <ResultGridRow>
+          <Flex align="center">
+            <Box flex="1">
+              <ObjectResult data={test} />
+              {test.name}
+            </Box>
+            <Box width={90} style={{textAlign: 'right'}}>
+              <AggregateDuration data={test.runs} />
+            </Box>
+          </Flex>
+          {this.state.expanded &&
+            <div>
+              {test.runs.map(run =>
+                <TestDetails test={run} params={params} key={run.id} />
+              )}
+            </div>}
+        </ResultGridRow>
+      </TestListItemLink>
+    );
+  }
+}
+
+export default class AggregateTestList extends Component {
+  static propTypes = {
+    testList: PropTypes.arrayOf(PropTypes.object).isRequired,
+    collapsable: PropTypes.bool,
+    maxVisible: PropTypes.number
+  };
+
+  static defaultProps = {
+    collapsable: false
+  };
+
+  render() {
+    return (
+      <ResultGrid>
+        <Header>
+          <Column>Test Case</Column>
+          <Column width={90} textAlign="right">
+            Duration
+          </Column>
+        </Header>
+        <Collapsable
+          collapsable={this.props.collapsable}
+          maxVisible={this.props.maxVisible}>
+          {this.props.testList.map(test => {
+            return (
+              <TestListItem params={this.props.params} test={test} key={test.name} />
+            );
+          })}
+        </Collapsable>
+      </ResultGrid>
+    );
+  }
+}
+
+const TestDetailsWrapper = styled.div`
+  margin-top: 10px;
+  padding: 10px 0 0 25px;
+  color: #39364e;
+  font-size: 13px;
+  line-height: 1.4em;
+  border-top: 1px solid #dbdae3;
+
+  pre {
+    font-size: inherit;
+  }
+`;
+
+const TestListItemLink = styled.a`
+  display: block;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f0eff5;
+  }
+`;

--- a/webapp/pages/BuildTestList.jsx
+++ b/webapp/pages/BuildTestList.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import AsyncPage from '../components/AsyncPage';
 import Section from '../components/Section';
-import TestList from '../components/TestList';
+import AggregateTestList from '../components/AggregateTestList';
 
 export default class BuildTestList extends AsyncPage {
   static contextTypes = {
@@ -21,7 +21,7 @@ export default class BuildTestList extends AsyncPage {
   renderBody() {
     return (
       <Section>
-        <TestList testList={this.state.testList} params={this.props.params} />
+        <AggregateTestList testList={this.state.testList} params={this.props.params} />
       </Section>
     );
   }

--- a/webapp/pages/Dashboard.jsx
+++ b/webapp/pages/Dashboard.jsx
@@ -39,7 +39,7 @@ class RepoListSection extends AsyncComponent {
       return (
         <Section>
           <p>
-            {"Looks like you haven't yet setup and repositories. "}
+            {"Looks like you haven't yet setup any repositories. "}
             <Link to="/settings/github/repos">Add a repository</Link> to get started.
           </p>
         </Section>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4101,6 +4101,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+percentile@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/percentile/-/percentile-1.2.0.tgz#fa3b05c1ffd355b35228529834e5fa37f0bd465d"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"

--- a/zeus/api/resources/build_tests.py
+++ b/zeus/api/resources/build_tests.py
@@ -1,13 +1,34 @@
-from flask import request
-from sqlalchemy.orm import contains_eager
+import re
 
+from flask import request
+from sqlalchemy.sql import func
+from sqlalchemy.types import String, TypeDecorator
+from sqlalchemy.dialects.postgresql import array_agg
+
+from zeus.config import db
 from zeus.constants import Result
 from zeus.models import Job, Build, TestCase
 
 from .base_build import BaseBuildResource
-from ..schemas import TestCaseSummarySchema
+from ..schemas import AggregateTestCaseSummarySchema
 
-testcases_schema = TestCaseSummarySchema(many=True, strict=True)
+testcases_schema = AggregateTestCaseSummarySchema(many=True, strict=True)
+
+
+# https://bitbucket.org/zzzeek/sqlalchemy/issues/3729/using-array_agg-around-row-function-does
+class ArrayOfRecord(TypeDecorator):
+    impl = String
+
+    def process_result_value(self, value, dialect):
+        elems = re.match(r"^\{(\".+?\")*\}$", value).group(1)
+        elems = [e for e in re.split(r'"(.*?)",?', elems) if e]
+        return [tuple(
+            re.findall(r'[^\(\),]+', e)
+        ) for e in elems]
+
+
+def array_agg_row(*arg):
+    return func.array_agg(func.row(*arg), type_=ArrayOfRecord)
 
 
 class BuildTestsResource(BaseBuildResource):
@@ -15,20 +36,28 @@ class BuildTestsResource(BaseBuildResource):
         """
         Return a list of test cases for a given build.
         """
-        query = TestCase.query.options(contains_eager('job')).join(
-            Job,
-            TestCase.job_id == Job.id,
-        ).filter(
+        job_ids = db.session.query(Job.id).filter(
             Job.build_id == build.id,
-        )
+        ).subquery()
+
+        query = db.session.query(
+            TestCase.hash,
+            TestCase.name,
+            array_agg_row(TestCase.id, TestCase.job_id, TestCase.duration,
+                          TestCase.result).label('runs'),
+        ).filter(
+            TestCase.job_id.in_(job_ids),
+        ).group_by(TestCase.hash, TestCase.name)
 
         result = request.args.get('result')
         if result:
             try:
-                query = query.filter(TestCase.result == getattr(Result, result))
+                query = query.filter(
+                    TestCase.result == getattr(Result, result))
             except AttributeError:
                 raise NotImplementedError
 
-        query = query.order_by((TestCase.result == Result.failed).desc(), TestCase.name.asc())
+        query = query.order_by(
+            (array_agg(TestCase.result).label('results').contains([Result.failed])).desc(), TestCase.name.asc())
 
         return self.paginate_with_schema(testcases_schema, query)

--- a/zeus/api/resources/job_tests.py
+++ b/zeus/api/resources/job_tests.py
@@ -8,8 +8,9 @@ from zeus.models import Job, TestCase
 from .base_job import BaseJobResource
 from ..schemas import TestCaseSummarySchema
 
-testcase_schema = TestCaseSummarySchema(strict=True)
-testcases_schema = TestCaseSummarySchema(many=True, strict=True)
+testcase_schema = TestCaseSummarySchema(strict=True, exclude=['job'])
+testcases_schema = TestCaseSummarySchema(
+    many=True, strict=True, exclude=['job'])
 
 
 class JobTestsResource(BaseJobResource):
@@ -27,11 +28,13 @@ class JobTestsResource(BaseJobResource):
         result = request.args.get('result')
         if result:
             try:
-                query = query.filter(TestCase.result == getattr(Result, result))
+                query = query.filter(
+                    TestCase.result == getattr(Result, result))
             except AttributeError:
                 raise NotImplementedError
 
-        query = query.order_by((TestCase.result == Result.failed).desc(), TestCase.name.asc())
+        query = query.order_by(
+            (TestCase.result == Result.failed).desc(), TestCase.name.asc())
 
         return self.respond_with_schema(testcases_schema, query)
 
@@ -44,7 +47,8 @@ class JobTestsResource(BaseJobResource):
             return self.respond(result.errors, 403)
         try:
             with db.session.begin_nested():
-                test = TestCase(repository_id=job.repository_id, job_id=job.id, **result.data)
+                test = TestCase(repository_id=job.repository_id,
+                                job_id=job.id, **result.data)
                 db.session.add(test)
             status = 201
         except IntegrityError:

--- a/zeus/api/resources/test_details.py
+++ b/zeus/api/resources/test_details.py
@@ -1,5 +1,5 @@
 from flask import Response
-from sqlalchemy.orm import undefer
+from sqlalchemy.orm import joinedload, undefer
 
 from zeus.config import db
 from zeus.models import TestCase
@@ -12,7 +12,10 @@ testcase_schema = TestCaseSchema(strict=True)
 
 class TestDetailsResource(Resource):
     def dispatch_request(self, test_id: str, *args, **kwargs) -> Response:
-        test = TestCase.query.options(undefer('message')).get(test_id)
+        test = TestCase.query.options(
+            undefer('message'),
+            joinedload('job'),
+        ).get(test_id)
         if not test:
             return self.not_found()
 

--- a/zeus/api/schemas/testcase.py
+++ b/zeus/api/schemas/testcase.py
@@ -1,20 +1,52 @@
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, pre_dump
+from uuid import UUID
+
+from zeus.constants import Result
+from zeus.utils.aggregation import aggregate_result
 
 from .fields import ResultField
+from .job import JobSchema
 
 
-class TestCaseSchema(Schema):
+class ExecutionSchema(Schema):
     id = fields.UUID(dump_only=True)
-    job_id = fields.UUID(dump_only=True)
-    name = fields.Str(required=True)
-    duration = fields.Number(required=False)
     result = ResultField(required=True)
+    duration = fields.Number()
+    job_id = fields.UUID(required=True)
+
+
+class AggregateTestCaseSummarySchema(Schema):
+    name = fields.Str(required=True)
+    hash = fields.Str(dump_only=True)
+    runs = fields.List(fields.Nested(ExecutionSchema), required=True)
+    result = ResultField(required=True)
+
+    @pre_dump
+    def process_aggregates(self, data):
+        return {
+            'name': data.name,
+            'runs': [{
+                'id': UUID(e[0]),
+                'job_id': UUID(e[1]),
+                'duration': int(e[2]),
+                'result': Result(int(e[3])),
+            } for e in data.runs],
+            'result': aggregate_result(Result(int(e[3])) for e in data.runs)
+        }
+
+
+class AggregateTestCaseSummarySchema(AggregateTestCaseSummarySchema):
     message = fields.Str(required=False)
 
 
 class TestCaseSummarySchema(Schema):
     id = fields.UUID(dump_only=True)
-    job_id = fields.UUID(dump_only=True)
-    name = fields.Str()
+    name = fields.Str(required=True)
+    hash = fields.Str(dump_only=True)
+    result = ResultField(required=True)
     duration = fields.Number()
-    result = ResultField()
+    job = fields.Nested(JobSchema, required=True)
+
+
+class TestCaseSchema(TestCaseSummarySchema):
+    message = fields.Str(required=False)


### PR DESCRIPTION
This makes a subtle change to the test list which will improve visibility into matrix builds which run the same test suite under multiple parameters (branching).

It uses aggregate entries with 'runs', and an aggregate result as well as 99th percentile duration. Expanding will expand all test runs within it, though the design isn't ideal here.