### PR TITLE
feat: Add support for go test -json output

### DIFF
--- a/tests/fixtures/sample-gotest.json
+++ b/tests/fixtures/sample-gotest.json
@@ -1,0 +1,17 @@
+{"Time":"2018-01-15T23:33:17.191475136+02:00","Action":"run","Package":"golang.org/x/sync/syncmap","Test":"TestMapMatchesRWMutex"}
+{"Time":"2018-01-15T23:33:17.19173721+02:00","Action":"output","Package":"golang.org/x/sync/syncmap","Test":"TestMapMatchesRWMutex","Output":"=== RUN   TestMapMatchesRWMutex\n"}
+{"Time":"2018-01-15T23:33:17.197200611+02:00","Action":"output","Package":"golang.org/x/sync/syncmap","Test":"TestMapMatchesRWMutex","Output":"--- PASS: TestMapMatchesRWMutex (0.01s)\n"}
+{"Time":"2018-01-15T23:33:17.197234575+02:00","Action":"pass","Package":"golang.org/x/sync/syncmap","Test":"TestMapMatchesRWMutex","Elapsed":0.01}
+{"Time":"2018-01-15T23:33:17.197257215+02:00","Action":"run","Package":"golang.org/x/sync/syncmap","Test":"TestMapMatchesDeepCopy"}
+{"Time":"2018-01-15T23:33:17.197268073+02:00","Action":"output","Package":"golang.org/x/sync/syncmap","Test":"TestMapMatchesDeepCopy","Output":"=== RUN   TestMapMatchesDeepCopy\n"}
+{"Time":"2018-01-15T23:33:17.205282906+02:00","Action":"output","Package":"golang.org/x/sync/syncmap","Test":"TestMapMatchesDeepCopy","Output":"--- PASS: TestMapMatchesDeepCopy (0.01s)\n"}
+{"Time":"2018-01-15T23:33:17.205331187+02:00","Action":"pass","Package":"golang.org/x/sync/syncmap","Test":"TestMapMatchesDeepCopy","Elapsed":0.01}
+{"Time":"2018-01-15T23:33:17.205346162+02:00","Action":"run","Package":"golang.org/x/sync/syncmap","Test":"TestConcurrentRange"}
+{"Time":"2018-01-15T23:33:17.205356304+02:00","Action":"output","Package":"golang.org/x/sync/syncmap","Test":"TestConcurrentRange","Output":"=== RUN   TestConcurrentRange\n"}
+{"Time":"2018-01-15T23:33:17.206151523+02:00","Action":"output","Package":"golang.org/x/sync/syncmap","Test":"TestConcurrentRange","Output":"--- FAIL: TestConcurrentRange (0.00s)\n"}
+{"Time":"2018-01-15T23:33:17.206180842+02:00","Action":"output","Package":"golang.org/x/sync/syncmap","Test":"TestConcurrentRange","Output":"\tmap_test.go:169: Range visited 1024 elements of 1024-element Map\n"}
+{"Time":"2018-01-15T23:33:17.206194909+02:00","Action":"fail","Package":"golang.org/x/sync/syncmap","Test":"TestConcurrentRange","Elapsed":0}
+{"Time":"2018-01-15T23:33:17.206216521+02:00","Action":"output","Package":"golang.org/x/sync/syncmap","Output":"FAIL\n"}
+{"Time":"2018-01-15T23:33:17.207362125+02:00","Action":"output","Package":"golang.org/x/sync/syncmap","Output":"exit status 1\n"}
+{"Time":"2018-01-15T23:33:17.207389986+02:00","Action":"output","Package":"golang.org/x/sync/syncmap","Output":"FAIL\tgolang.org/x/sync/syncmap\t0.022s\n"}
+{"Time":"2018-01-15T23:33:17.207407778+02:00","Action":"fail","Package":"golang.org/x/sync/syncmap","Elapsed":0.022}

--- a/tests/zeus/artifacts/test_gotest.py
+++ b/tests/zeus/artifacts/test_gotest.py
@@ -1,0 +1,39 @@
+from io import BytesIO
+
+from zeus.artifacts.gotest import GoTestHandler
+from zeus.constants import Result
+from zeus.models import Job
+from zeus.utils.testresult import TestResult as ZeusTestResult
+
+
+def test_result_generation(sample_gotest):
+    job = Job()
+
+    fp = BytesIO(sample_gotest.encode('utf8'))
+
+    handler = GoTestHandler(job)
+    results = handler.get_tests(fp)
+
+    assert len(results) == 3
+
+    r1 = results[0]
+    assert type(r1) == ZeusTestResult
+    assert r1.job == job
+    assert r1.name == 'golang.org/x/sync/syncmap/TestMapMatchesRWMutex'
+    assert r1.duration == 10.0
+    assert r1.result == Result.passed
+    assert r1.message is None
+    r2 = results[1]
+    assert type(r2) == ZeusTestResult
+    assert r2.job == job
+    assert r2.name == 'golang.org/x/sync/syncmap/TestMapMatchesDeepCopy'
+    assert r2.duration == 10.0
+    assert r2.result == Result.passed
+    assert r2.message is None
+    r3 = results[2]
+    assert type(r3) == ZeusTestResult
+    assert r3.job == job
+    assert r3.name == 'golang.org/x/sync/syncmap/TestConcurrentRange'
+    assert r3.duration == 0.0
+    assert r3.result == Result.failed
+    assert r3.message == '\tmap_test.go:169: Range visited 1024 elements of 1024-element Map\n'

--- a/zeus/artifacts/__init__.py
+++ b/zeus/artifacts/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function
 from .manager import Manager
 from .checkstyle import CheckstyleHandler
 from .coverage import CoverageHandler
+from .gotest import GoTestHandler
 from .pycodestyle import PyCodeStyleHandler
 from .pylint import PyLintHandler
 from .webpack import WebpackStatsHandler
@@ -13,6 +14,8 @@ manager.register(CheckstyleHandler, [
                  'checkstyle.xml', '*.checkstyle.xml'])
 manager.register(CoverageHandler, [
                  'coverage.xml', '*.coverage.xml'])
+manager.register(GoTestHandler, [
+                 'gotest.json', '*.gotest.json'])
 manager.register(PyCodeStyleHandler, [
                  'pep8.txt', '*.pep8.txt', 'pep8.log', '*.pep8.log', 'pycodestyle.txt', '*.pycodestyle.txt', 'pycodestyle.log', '*.pycodestyle.log'])
 manager.register(PyLintHandler, [

--- a/zeus/artifacts/gotest.py
+++ b/zeus/artifacts/gotest.py
@@ -1,0 +1,61 @@
+from flask import current_app
+import json
+
+from zeus.constants import Result
+from zeus.utils.testresult import TestResult, TestResultManager
+
+from .base import ArtifactHandler
+
+
+class GoTestHandler(ArtifactHandler):
+    supported_types = frozenset(['application/x-gotest+json'])
+
+    def process(self, fp):
+        test_list = self.get_tests(fp)
+
+        manager = TestResultManager(self.job)
+        manager.clear()
+        manager.save(test_list)
+
+        return test_list
+
+    def get_tests(self, fp):
+        job = self.job
+
+        results = []
+
+        actionToResult = {
+            'pass': Result.passed,
+            'fail': Result.failed,
+        }
+        last_output = {}
+        for lineno, line in enumerate(fp.readlines()):
+            # Format at https://tip.golang.org/cmd/test2json/
+            try:
+                event = json.loads(line)
+            except Exception:
+                current_app.logger.exception(
+                    'Failed to parse JSON on line %d', lineno + 1)
+                return []
+
+            if 'Test' not in event:
+                continue
+
+            key = (event.get('Package'), event['Test'])
+            output = event.get('Output') or last_output.get(key)
+            if output:
+                last_output[key] = output
+
+            result = actionToResult.get(event['Action'])
+            if result is None:
+                continue
+            results.append(TestResult(
+                job=job,
+                name=event['Test'],
+                message=output if result == Result.failed else None,
+                package=event.get('Package'),
+                result=result,
+                duration=int(event['Elapsed'] * 1000),
+            ))
+
+        return results

--- a/zeus/testutils/fixtures.py
+++ b/zeus/testutils/fixtures.py
@@ -229,6 +229,12 @@ def sample_pylint(fixture_path):
 
 
 @pytest.fixture(scope='session')
+def sample_gotest(fixture_path):
+    with open(os.path.join(fixture_path, 'sample-gotest.json')) as fp:
+        return fp.read()
+
+
+@pytest.fixture(scope='session')
 def sample_webpack_stats(fixture_path):
     with open(os.path.join(fixture_path, 'webpack-stats.json')) as fp:
         return fp.read()


### PR DESCRIPTION
The upcoming release of go1.10 includes machine parseable test output.