### PR TITLE
feat: Add failure origin to aggregate test cases

### DIFF
--- a/tests/zeus/api/resources/test_user_builds.py
+++ b/tests/zeus/api/resources/test_user_builds.py
@@ -1,3 +1,6 @@
+
+from datetime import timedelta
+
 from zeus import factories
 
 
@@ -14,8 +17,12 @@ def test_user_build_list(
     factories.BuildFactory(repository=default_repo)
 
     # "my" builds
-    build1 = factories.BuildFactory(repository=default_repo, source=default_source)
     build2 = factories.BuildFactory(repository=default_repo, source=default_source)
+    build1 = factories.BuildFactory(
+        repository=default_repo,
+        source=default_source,
+        date_created=build2.date_created - timedelta(minutes=1),
+    )
 
     # Queries:
     # - Tenant

--- a/tests/zeus/api/schemas/test_testcase.py
+++ b/tests/zeus/api/schemas/test_testcase.py
@@ -1,0 +1,98 @@
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import List, Tuple
+
+from zeus import auth, factories
+from zeus.constants import Permission, Result
+from zeus.api.schemas import AggregateTestCaseSummarySchema
+
+
+@dataclass
+class AggregateTestCase:
+    hash: str
+    name: str
+    # [id, job_id, duration, result]
+    runs: List[Tuple[str, str, int, Result]]
+
+
+def test_failure_origin(default_repo):
+    auth.set_current_tenant(auth.Tenant(access={default_repo.id: Permission.read}))
+
+    new_revision = factories.RevisionFactory(repository=default_repo)
+    new_source = factories.SourceFactory(revision=new_revision)
+    new_build = factories.BuildFactory(source=new_source, failed=True)
+    new_job = factories.JobFactory(build=new_build, failed=True)
+    new_testcase = factories.TestCaseFactory(job=new_job, failed=True)
+    new_testcase2 = factories.TestCaseFactory(job=new_job, passed=True)
+
+    old_revision = factories.RevisionFactory(
+        repository=default_repo,
+        date_created=new_revision.date_created - timedelta(hours=1),
+    )
+    old_source = factories.SourceFactory(
+        revision=old_revision, date_created=new_source.date_created - timedelta(hours=1)
+    )
+    old_build = factories.BuildFactory(
+        source=old_source,
+        failed=True,
+        date_created=new_build.date_created - timedelta(hours=1),
+    )
+    old_job = factories.JobFactory(
+        build=old_build,
+        failed=True,
+        date_created=new_job.date_created - timedelta(hours=1),
+    )
+    factories.TestCaseFactory(job=old_job, failed=True, name=new_testcase.name)
+
+    oldold_revision = factories.RevisionFactory(
+        repository=default_repo,
+        date_created=old_revision.date_created - timedelta(hours=1),
+    )
+    oldold_source = factories.SourceFactory(
+        revision=oldold_revision,
+        date_created=old_source.date_created - timedelta(hours=1),
+    )
+    factories.BuildFactory(
+        source=oldold_source,
+        passed=True,
+        date_created=old_build.date_created - timedelta(hours=1),
+    )
+
+    schema = AggregateTestCaseSummarySchema(
+        many=True, strict=True, context={"build": new_build}
+    )
+    result = schema.dump(
+        [
+            AggregateTestCase(
+                hash=new_testcase.hash,
+                name=new_testcase.name,
+                runs=[
+                    [
+                        str(new_testcase.id),
+                        str(new_testcase.job_id),
+                        new_testcase.duration,
+                        new_testcase.result,
+                    ]
+                ],
+            ),
+            AggregateTestCase(
+                hash=new_testcase2.hash,
+                name=new_testcase2.name,
+                runs=[
+                    [
+                        str(new_testcase2.id),
+                        str(new_testcase2.job_id),
+                        new_testcase2.duration,
+                        new_testcase2.result,
+                    ]
+                ],
+            ),
+        ]
+    ).data
+    assert len(result) == 2
+    assert result[0]["hash"] == new_testcase.hash
+    assert result[0]["name"] == new_testcase.name
+    assert result[0]["origin_build"]["id"] == str(old_build.id)
+    assert result[1]["hash"] == new_testcase2.hash
+    assert result[1]["name"] == new_testcase2.name
+    assert result[1]["origin_build"] is None

--- a/zeus/api/resources/build_tests.py
+++ b/zeus/api/resources/build_tests.py
@@ -9,8 +9,6 @@ from zeus.models import Job, Build, TestCase
 from .base_build import BaseBuildResource
 from ..schemas import AggregateTestCaseSummarySchema
 
-testcases_schema = AggregateTestCaseSummarySchema(many=True, strict=True)
-
 
 class BuildTestsResource(BaseBuildResource):
     def get(self, build: Build):
@@ -50,4 +48,7 @@ class BuildTestsResource(BaseBuildResource):
             TestCase.name.asc(),
         )
 
-        return self.paginate_with_schema(testcases_schema, query)
+        schema = AggregateTestCaseSummarySchema(
+            many=True, strict=True, context={"build": build}
+        )
+        return self.paginate_with_schema(schema, query)

--- a/zeus/api/schemas/testcase.py
+++ b/zeus/api/schemas/testcase.py
@@ -1,11 +1,130 @@
+from collections import defaultdict
 from marshmallow import Schema, fields, pre_dump
+from typing import List, Mapping
 from uuid import UUID
 
-from zeus.constants import Result
+from zeus.config import db
+from zeus.constants import Result, Status
+from zeus.models import Build, Job, Source, TestCase
 from zeus.utils.aggregation import aggregate_result
+from zeus.vcs.base import UnknownRevision
 
+from .build import BuildSchema
 from .fields import ResultField
 from .job import JobSchema
+
+
+def find_failure_origins(build: Build, test_failures: List[str]) -> Mapping[str, UUID]:
+    """
+    Attempt to find originating causes of failures.
+
+    Returns a mapping of {TestCase.hash: Job}.
+    """
+    if not test_failures:
+        return {}
+
+    source = build.source
+    repo = build.repository
+    vcs = repo.get_vcs()
+    if not vcs:
+        valid_revisions = []
+    else:
+        try:
+            valid_revisions = [
+                c.sha for c in vcs.log(limit=100, parent=source.revision_sha)
+            ]
+        except UnknownRevision:
+            valid_revisions = []
+
+    filters = [
+        Build.repository_id == build.repository_id,
+        Build.date_created <= build.date_created,
+        Build.status == Status.finished,
+        Source.id != source.id,
+        Source.date_created <= source.date_created,
+        Source.patch == None,  # NOQA
+    ]
+    if valid_revisions:
+        filters.append(Source.revision_sha.in_(valid_revisions))
+
+    # NOTE(dcramer): many of these queries ignore tenant constraints
+    # find any existing failures in the previous runs
+    # to do this we first need to find the last passing build
+    last_pass = (
+        db.session.query(Source.id, Source.date_created)
+        .join(Build, Source.id == Build.source_id)
+        .filter(Build.result == Result.passed, *filters)
+        .order_by(Source.date_created.desc())
+        .first()
+    )
+
+    if last_pass:
+        last_pass_source_id, last_pass_date = last_pass
+
+        # We have to query all runs between build and last_pass. Because we're
+        # paranoid about performance, we limit this to 100 results.
+        previous_build_ids = [
+            r
+            for r, in db.session.query(Build.id)
+            .join(Source, Source.id == build.source_id)
+            .filter(
+                Build.result == Result.failed,
+                Build.date_created >= last_pass_date,
+                Source.date_created >= last_pass_date,
+                Source.id != last_pass_source_id,
+                # *filters,
+            )
+            .order_by(Source.date_created.desc())[:100]
+        ]
+        print(previous_build_ids)
+    else:
+        previous_build_ids = [
+            r
+            for r, in db.session.query(Build.id)
+            .join(Source, Source.id == build.source_id)
+            .filter(Build.result == Result.failed, *filters)
+            .order_by(Source.date_created.desc())[:100]
+        ]
+
+    if not previous_build_ids:
+        return {}
+
+    # we now have a list of previous_runs so let's find all test failures in
+    # these runs
+    queryset = (
+        db.session.query(TestCase.hash, Job.build_id)
+        .join(Job, Job.id == TestCase.job_id)
+        .filter(
+            Job.build_id.in_(previous_build_ids),
+            Job.status == Status.finished,
+            Job.result == Result.failed,
+            TestCase.result == Result.failed,
+            TestCase.hash.in_(test_failures),
+        )
+        .group_by(TestCase.hash, Job.build_id)
+    )
+
+    previous_test_failures = defaultdict(set)
+    for test_hash, build_id in queryset:
+        previous_test_failures[build_id].add(test_hash)
+
+    failures_at_build = dict()
+    searching = set(t for t in test_failures)
+    last_checked_run = build.id
+
+    for p_build in previous_build_ids:
+        p_build_failures = previous_test_failures[p_build]
+        # we have to copy the set as it might change size during iteration
+        for f_test in list(searching):
+            if f_test not in p_build_failures:
+                failures_at_build[f_test] = last_checked_run
+                searching.remove(f_test)
+        last_checked_run = p_build
+
+    for f_test in searching:
+        failures_at_build[f_test] = last_checked_run
+
+    return failures_at_build
 
 
 class ExecutionSchema(Schema):
@@ -21,22 +140,58 @@ class AggregateTestCaseSummarySchema(Schema):
     runs = fields.List(fields.Nested(ExecutionSchema), required=True)
     result = ResultField(required=True)
     message = fields.Str(required=False)
+    origin_build = fields.Nested(
+        BuildSchema(exclude=("repository", "source", "stats")), required=False
+    )
 
-    @pre_dump
-    def process_aggregates(self, data):
-        return {
-            "name": data.name,
-            "runs": [
-                {
-                    "id": UUID(e[0]),
-                    "job_id": UUID(e[1]),
-                    "duration": int(e[2]),
-                    "result": Result(int(e[3])),
-                }
-                for e in data.runs
-            ],
-            "result": aggregate_result(Result(int(e[3])) for e in data.runs),
-        }
+    @pre_dump(pass_many=True)
+    def process_aggregates(self, data, many):
+        if not many:
+            items = [data]
+        else:
+            items = data
+
+        if "origin_build" in self.exclude or "build" not in self.context:
+            failure_origins = {}
+        else:
+            # TODO(dcramer): technically this could support multiple builds,
+            # or identify the referenced build
+            failure_origins = find_failure_origins(
+                self.context["build"],
+                [i.hash for i in items if any(e[3] == Result.failed for e in i.runs)],
+            )
+
+        if failure_origins:
+            origin_builds = {
+                b.id: b
+                for b in Build.query.filter(
+                    Build.id.in_(frozenset(failure_origins.values()))
+                )
+            }
+        else:
+            origin_builds = {}
+
+        results = [
+            {
+                "hash": i.hash,
+                "name": i.name,
+                "runs": [
+                    {
+                        "id": UUID(e[0]),
+                        "job_id": UUID(e[1]),
+                        "duration": int(e[2]),
+                        "result": Result(int(e[3])),
+                    }
+                    for e in i.runs
+                ],
+                "origin_build": origin_builds.get(failure_origins.get(i.hash)),
+                "result": aggregate_result(Result(int(e[3])) for e in i.runs),
+            }
+            for i in items
+        ]
+        if many:
+            return results
+        return results[0]
 
 
 class TestCaseSummarySchema(Schema):

--- a/zeus/factories/build.py
+++ b/zeus/factories/build.py
@@ -6,7 +6,6 @@ from random import randint
 
 from zeus import models
 from zeus.constants import Result, Status
-from zeus.utils import timezone
 
 from .base import ModelFactory
 from .types import GUIDFactory
@@ -27,9 +26,7 @@ class BuildFactory(ModelFactory):
     repository_id = factory.SelfAttribute("repository.id")
     result = factory.Iterator([Result.failed, Result.passed])
     status = factory.Iterator([Status.queued, Status.in_progress, Status.finished])
-    date_created = factory.LazyAttribute(
-        lambda o: timezone.now() - timedelta(minutes=30)
-    )
+    date_created = factory.SelfAttribute("source.date_created")
     date_started = factory.LazyAttribute(
         lambda o: (
             faker.date_time_between(

--- a/zeus/factories/revision.py
+++ b/zeus/factories/revision.py
@@ -1,11 +1,13 @@
 import factory
 import factory.faker
 
+from datetime import timedelta
 from faker import Factory
 
 faker = Factory.create()
 
 from zeus import models
+from zeus.utils import timezone
 
 from .base import ModelFactory
 
@@ -20,6 +22,9 @@ class RevisionFactory(ModelFactory):
     author_id = factory.SelfAttribute("author.id")
     message = factory.LazyAttribute(
         lambda o: "{}\n\n{}".format(faker.sentence(), faker.sentence())
+    )
+    date_created = factory.LazyAttribute(
+        lambda o: timezone.now() - timedelta(minutes=30)
     )
 
     class Meta:

--- a/zeus/factories/source.py
+++ b/zeus/factories/source.py
@@ -14,6 +14,7 @@ class SourceFactory(ModelFactory):
     revision_sha = factory.SelfAttribute("revision.sha")
     author = factory.SelfAttribute("revision.author")
     author_id = factory.SelfAttribute("author.id")
+    date_created = factory.SelfAttribute("revision.date_created")
 
     class Meta:
         model = models.Source


### PR DESCRIPTION
While this should be fairly accurate, it isn't going to be perfect. Right now if a build is created as part of a change request (e.g. in a branch), and it coincidentally has a failing test which is the same as your branch, we'd likely point to it as the origin.