### PR TITLE
fix: Start/finish time comparison in case of multiple providers

### DIFF
--- a/tests/zeus/utils/test_builds.py
+++ b/tests/zeus/utils/test_builds.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timedelta
+
+from zeus import factories
+from zeus.constants import Status, Result
+from zeus.utils.builds import merge_build_group
+
+
+def test_merge_build_group_different_providers(client, default_login, default_source):
+    now = datetime.now()
+    later = now + timedelta(minutes=1)
+    build1 = factories.BuildFactory.create(
+        source=default_source, provider="provider1", date_started=now, date_finished=now
+    )
+    build2 = factories.BuildFactory.create(
+        source=default_source,
+        provider="provider2",
+        date_started=later,
+        date_finished=later,
+    )
+
+    merged_build = merge_build_group([build1, build2])
+
+    assert merged_build.source == default_source
+    assert merged_build.label == default_source.revision.message
+    assert merged_build.original == [build1, build2]
+    assert merged_build.status == Status(max(build1.status.value, build2.status.value))
+    assert merged_build.result == Result(max(build1.result.value, build2.result.value))
+    assert merged_build.date_started == now
+    assert merged_build.date_finished == later
+    assert merged_build.provider == "provider1, provider2"
+
+
+def test_merge_build_group_empty_dates(client, default_login, default_source):
+    now = datetime.now()
+    build1 = factories.BuildFactory.create(
+        source=default_source, provider="provider1", date_started=now, date_finished=now
+    )
+    build2 = factories.BuildFactory.create(
+        source=default_source,
+        provider="provider2",
+        date_started=None,
+        date_finished=None,
+    )
+
+    merged_build = merge_build_group([build1, build2])
+
+    assert merged_build.date_started == now
+    assert merged_build.date_finished == now

--- a/zeus/utils/builds.py
+++ b/zeus/utils/builds.py
@@ -34,13 +34,13 @@ def merge_builds(target, build):
     )
     target.date_started = (
         min(target.date_started, build.date_started)
-        if target.date_started
-        else build.date_started
+        if target.date_started and build.date_started
+        else target.date_started or build.date_started
     )
     target.date_finished = (
         max(target.date_finished, build.date_finished)
-        if target.date_finished
-        else build.date_finished
+        if target.date_finished and build.date_finished
+        else target.date_finished or build.date_finished
     )
     target.provider = (
         "%s, %s" % (target.provider, build.provider)


### PR DESCRIPTION
This should fix
https://sentry.io/sentry/zeus/issues/611142817/?environment=production
https://sentry.io/sentry/zeus/issues/622534124/?environment=production