### PR TITLE
feat: Use unique provider names for constraints

### DIFF
--- a/tests/fixtures/travis-build-commit.json
+++ b/tests/fixtures/travis-build-commit.json
@@ -1,169 +1,139 @@
 {
-    "id": 288639281,
-    "number": "2843",
-    "config": {
-      "sudo": false,
-      "dist": "trusty",
-      "language": "python",
-      "python": [
-        "3.5.2"
-      ],
-      "branches": {
-        "only": [
-          "master"
-        ]
-      },
-      "cache": {
-        "pip": true,
-        "directories": [
-          "vendor/bundle",
-          "node_modules"
-        ]
-      },
-      "deploy": {
-        "provider": "heroku",
-        "api_key": {
-          "secure": "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
-        },
-        "app": "docs-travis-ci-com",
-        "skip_cleanup": true,
-        "true": {
-          "branch": [
-            "master"
-          ]
-        }
-      },
-      "notifications": {
-        "slack": {
-          "rooms": {
-            "secure": "LPNgf0Ra6Vu6I7XuK7tcnyFWJg+becx1RfAR35feWK81sru8TyuldQIt7uAKMA8tqFTP8j1Af7iz7UDokbCCfDNCX1GxdAWgXs+UKpwhO89nsidHAsCkW2lWSEM0E3xtOJDyNFoauiHxBKGKUsApJTnf39H+EW9tWrqN5W2sZg8="
-          },
-          "on_success": "never"
-        },
-        "webhooks": "https://docs.travis-ci.com/update_webhook_payload_doc"
-      },
-      "install": [
-        "rvm use 2.3.1 --install",
-        "bundle install --deployment"
-      ],
-      "script": [
-        "bundle exec rake test"
-      ],
-      ".result": "configured",
-      "global_env": [
-        "PATH=$HOME/.local/user/bin:$PATH"
-      ],
-      "group": "stable"
+  "id": 288639281,
+  "number": "2843",
+  "config": {
+    "sudo": false,
+    "dist": "trusty",
+    "language": "python",
+    "python": ["3.5.2"],
+    "branches": {
+      "only": ["master"]
     },
-    "type": "cron",
-    "state": "passed",
-    "status": 0,
-    "result": 0,
-    "status_message": "Passed",
-    "result_message": "Passed",
-    "started_at": "2017-10-16T16:08:56Z",
-    "finished_at": "2017-10-16T16:12:35Z",
-    "duration": 219,
-    "build_url": "https://travis-ci.org/travis-ci/docs-travis-ci-com/builds/288639281",
-    "commit_id": 84531696,
-    "commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
-    "base_commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
-    "head_commit": null,
-    "branch": "master",
-    "message": "Merge pull request #1389 from christopher-dG/patch-1\\n\\nJulia: Refer to PkgDev's generate instead of Pkg's",
-    "compare_url": "https://github.com/travis-ci/docs-travis-ci-com/compare/eb58bd2fac2e339d0339689d9eb7290246805a1d...d79e3a6ff0cada29d731ed93de203f76a81d02c0",
-    "committed_at": "2017-10-16T14:56:34Z",
-    "author_name": "Plaindocs",
-    "author_email": "lykoszine@gmail.com",
-    "committer_name": "GitHub",
-    "committer_email": "noreply@github.com",
-    "pull_request": false,
-    "pull_request_number": null,
-    "pull_request_title": null,
-    "tag": null,
-    "repository": {
-      "id": 1771959,
-      "name": "docs-travis-ci-com",
-      "owner_name": "travis-ci",
-      "url": "http://docs.travis-ci.com"
+    "cache": {
+      "pip": true,
+      "directories": ["vendor/bundle", "node_modules"]
     },
-    "matrix": [
-      {
-        "id": 288639284,
-        "repository_id": 1771959,
-        "parent_id": 288639281,
-        "number": "2843.1",
-        "state": "passed",
-        "config": {
-          "sudo": false,
-          "dist": "trusty",
-          "language": "python",
-          "python": "3.5.2",
-          "branches": {
-            "only": [
-              "master"
-            ]
-          },
-          "env": ["TEST_SUITE=integration"],
-          "cache": {
-            "pip": true,
-            "directories": [
-              "vendor/bundle",
-              "node_modules"
-            ]
-          },
-          "notifications": {
-            "slack": {
-              "rooms": {
-                "secure": "LPNgf0Ra6Vu6I7XuK7tcnyFWJg+becx1RfAR35feWK81sru8TyuldQIt7uAKMA8tqFTP8j1Af7iz7UDokbCCfDNCX1GxdAWgXs+UKpwhO89nsidHAsCkW2lWSEM0E3xtOJDyNFoauiHxBKGKUsApJTnf39H+EW9tWrqN5W2sZg8="
-              },
-              "on_success": "never"
+    "deploy": {
+      "provider": "heroku",
+      "api_key": {
+        "secure": "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
+      },
+      "app": "docs-travis-ci-com",
+      "skip_cleanup": true,
+      "true": {
+        "branch": ["master"]
+      }
+    },
+    "notifications": {
+      "slack": {
+        "rooms": {
+          "secure": "LPNgf0Ra6Vu6I7XuK7tcnyFWJg+becx1RfAR35feWK81sru8TyuldQIt7uAKMA8tqFTP8j1Af7iz7UDokbCCfDNCX1GxdAWgXs+UKpwhO89nsidHAsCkW2lWSEM0E3xtOJDyNFoauiHxBKGKUsApJTnf39H+EW9tWrqN5W2sZg8="
+        },
+        "on_success": "never"
+      },
+      "webhooks": "https://docs.travis-ci.com/update_webhook_payload_doc"
+    },
+    "install": ["rvm use 2.3.1 --install", "bundle install --deployment"],
+    "script": ["bundle exec rake test"],
+    ".result": "configured",
+    "global_env": ["PATH=$HOME/.local/user/bin:$PATH"],
+    "group": "stable"
+  },
+  "type": "cron",
+  "state": "passed",
+  "status": 0,
+  "result": 0,
+  "status_message": "Passed",
+  "result_message": "Passed",
+  "started_at": "2017-10-16T16:08:56Z",
+  "finished_at": "2017-10-16T16:12:35Z",
+  "duration": 219,
+  "build_url": "https://travis-ci.org/travis-ci/docs-travis-ci-com/builds/288639281",
+  "commit_id": 84531696,
+  "commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
+  "base_commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
+  "head_commit": null,
+  "branch": "master",
+  "message": "Merge pull request #1389 from christopher-dG/patch-1\\n\\nJulia: Refer to PkgDev's generate instead of Pkg's",
+  "compare_url": "https://github.com/travis-ci/docs-travis-ci-com/compare/eb58bd2fac2e339d0339689d9eb7290246805a1d...d79e3a6ff0cada29d731ed93de203f76a81d02c0",
+  "committed_at": "2017-10-16T14:56:34Z",
+  "author_name": "Plaindocs",
+  "author_email": "lykoszine@gmail.com",
+  "committer_name": "GitHub",
+  "committer_email": "noreply@github.com",
+  "pull_request": false,
+  "pull_request_number": null,
+  "pull_request_title": null,
+  "tag": null,
+  "repository": {
+    "id": 1771959,
+    "name": "docs-travis-ci-com",
+    "owner_name": "travis-ci",
+    "url": "http://docs.travis-ci.com"
+  },
+  "matrix": [
+    {
+      "id": 288639284,
+      "repository_id": 1771959,
+      "parent_id": 288639281,
+      "number": "2843.1",
+      "state": "passed",
+      "config": {
+        "sudo": false,
+        "dist": "trusty",
+        "language": "python",
+        "python": "3.5.2",
+        "branches": {
+          "only": ["master"]
+        },
+        "env": ["TEST_SUITE=integration"],
+        "cache": {
+          "pip": true,
+          "directories": ["vendor/bundle", "node_modules"]
+        },
+        "notifications": {
+          "slack": {
+            "rooms": {
+              "secure": "LPNgf0Ra6Vu6I7XuK7tcnyFWJg+becx1RfAR35feWK81sru8TyuldQIt7uAKMA8tqFTP8j1Af7iz7UDokbCCfDNCX1GxdAWgXs+UKpwhO89nsidHAsCkW2lWSEM0E3xtOJDyNFoauiHxBKGKUsApJTnf39H+EW9tWrqN5W2sZg8="
             },
-            "webhooks": "https://docs.travis-ci.com/update_webhook_payload_doc"
+            "on_success": "never"
           },
-          "install": [
-            "rvm use 2.3.1 --install",
-            "bundle install --deployment"
-          ],
-          "script": [
-            "bundle exec rake test"
-          ],
-          ".result": "configured",
-          "global_env": [
-            "PATH=$HOME/.local/user/bin:$PATH"
-          ],
-          "group": "stable",
-          "os": "linux",
-          "addons": {
-            "deploy": {
-              "provider": "heroku",
-              "api_key": {
-                "secure": "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
-              },
-              "app": "docs-travis-ci-com",
-              "skip_cleanup": true,
-              "true": {
-                "branch": [
-                  "master"
-                ]
-              }
+          "webhooks": "https://docs.travis-ci.com/update_webhook_payload_doc"
+        },
+        "install": ["rvm use 2.3.1 --install", "bundle install --deployment"],
+        "script": ["bundle exec rake test"],
+        ".result": "configured",
+        "global_env": ["PATH=$HOME/.local/user/bin:$PATH"],
+        "group": "stable",
+        "os": "linux",
+        "addons": {
+          "deploy": {
+            "provider": "heroku",
+            "api_key": {
+              "secure": "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
+            },
+            "app": "docs-travis-ci-com",
+            "skip_cleanup": true,
+            "true": {
+              "branch": ["master"]
             }
           }
-        },
-        "status": 0,
-        "result": 0,
-        "commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
-        "branch": "master",
-        "message": "Merge pull request #1389 from christopher-dG/patch-1\\n\\nJulia: Refer to PkgDev's generate instead of Pkg's",
-        "compare_url": "https://github.com/travis-ci/docs-travis-ci-com/compare/eb58bd2fac2e339d0339689d9eb7290246805a1d...d79e3a6ff0cada29d731ed93de203f76a81d02c0",
-        "started_at": null,
-        "finished_at": null,
-        "committed_at": "2017-10-16T14:56:34Z",
-        "author_name": "Plaindocs",
-        "author_email": "lykoszine@gmail.com",
-        "committer_name": "GitHub",
-        "committer_email": "noreply@github.com",
-        "allow_failure": true
-      }
-    ]
-  }
+        }
+      },
+      "status": 0,
+      "result": 0,
+      "commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
+      "branch": "master",
+      "message": "Merge pull request #1389 from christopher-dG/patch-1\\n\\nJulia: Refer to PkgDev's generate instead of Pkg's",
+      "compare_url": "https://github.com/travis-ci/docs-travis-ci-com/compare/eb58bd2fac2e339d0339689d9eb7290246805a1d...d79e3a6ff0cada29d731ed93de203f76a81d02c0",
+      "started_at": null,
+      "finished_at": null,
+      "committed_at": "2017-10-16T14:56:34Z",
+      "author_name": "Plaindocs",
+      "author_email": "lykoszine@gmail.com",
+      "committer_name": "GitHub",
+      "committer_email": "noreply@github.com",
+      "allow_failure": true
+    }
+  ]
+}

--- a/tests/fixtures/travis-build-pull-request.json
+++ b/tests/fixtures/travis-build-pull-request.json
@@ -1,169 +1,139 @@
 {
-    "id": 288639281,
-    "number": "2843",
-    "config": {
-      "sudo": false,
-      "dist": "trusty",
-      "language": "python",
-      "python": [
-        "3.5.2"
-      ],
-      "branches": {
-        "only": [
-          "master"
-        ]
-      },
-      "cache": {
-        "pip": true,
-        "directories": [
-          "vendor/bundle",
-          "node_modules"
-        ]
-      },
-      "deploy": {
-        "provider": "heroku",
-        "api_key": {
-          "secure": "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
-        },
-        "app": "docs-travis-ci-com",
-        "skip_cleanup": true,
-        "true": {
-          "branch": [
-            "master"
-          ]
-        }
-      },
-      "notifications": {
-        "slack": {
-          "rooms": {
-            "secure": "LPNgf0Ra6Vu6I7XuK7tcnyFWJg+becx1RfAR35feWK81sru8TyuldQIt7uAKMA8tqFTP8j1Af7iz7UDokbCCfDNCX1GxdAWgXs+UKpwhO89nsidHAsCkW2lWSEM0E3xtOJDyNFoauiHxBKGKUsApJTnf39H+EW9tWrqN5W2sZg8="
-          },
-          "on_success": "never"
-        },
-        "webhooks": "https://docs.travis-ci.com/update_webhook_payload_doc"
-      },
-      "install": [
-        "rvm use 2.3.1 --install",
-        "bundle install --deployment"
-      ],
-      "script": [
-        "bundle exec rake test"
-      ],
-      ".result": "configured",
-      "global_env": [
-        "PATH=$HOME/.local/user/bin:$PATH"
-      ],
-      "group": "stable"
+  "id": 288639281,
+  "number": "2843",
+  "config": {
+    "sudo": false,
+    "dist": "trusty",
+    "language": "python",
+    "python": ["3.5.2"],
+    "branches": {
+      "only": ["master"]
     },
-    "type": "cron",
-    "state": "passed",
-    "status": 0,
-    "result": 0,
-    "status_message": "Passed",
-    "result_message": "Passed",
-    "started_at": "2017-10-16T16:08:56Z",
-    "finished_at": "2017-10-16T16:12:35Z",
-    "duration": 219,
-    "build_url": "https://travis-ci.org/travis-ci/docs-travis-ci-com/builds/288639281",
-    "commit_id": 84531696,
-    "commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
-    "base_commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
-    "head_commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
-    "branch": "master",
-    "message": "Merge pull request #1389 from christopher-dG/patch-1\\n\\nJulia: Refer to PkgDev's generate instead of Pkg's",
-    "compare_url": "https://github.com/travis-ci/docs-travis-ci-com/compare/eb58bd2fac2e339d0339689d9eb7290246805a1d...d79e3a6ff0cada29d731ed93de203f76a81d02c0",
-    "committed_at": "2017-10-16T14:56:34Z",
-    "author_name": "Plaindocs",
-    "author_email": "lykoszine@gmail.com",
-    "committer_name": "GitHub",
-    "committer_email": "noreply@github.com",
-    "pull_request": true,
-    "pull_request_number": 123,
-    "pull_request_title": "The title of the pull request",
-    "tag": null,
-    "repository": {
-      "id": 1771959,
-      "name": "docs-travis-ci-com",
-      "owner_name": "travis-ci",
-      "url": "http://docs.travis-ci.com"
+    "cache": {
+      "pip": true,
+      "directories": ["vendor/bundle", "node_modules"]
     },
-    "matrix": [
-      {
-        "id": 288639284,
-        "repository_id": 1771959,
-        "parent_id": 288639281,
-        "number": "2843.1",
-        "state": "passed",
-        "config": {
-          "sudo": false,
-          "dist": "trusty",
-          "language": "python",
-          "python": "3.5.2",
-          "branches": {
-            "only": [
-              "master"
-            ]
-          },
-          "env": ["TEST_SUITE=integration"],
-          "cache": {
-            "pip": true,
-            "directories": [
-              "vendor/bundle",
-              "node_modules"
-            ]
-          },
-          "notifications": {
-            "slack": {
-              "rooms": {
-                "secure": "LPNgf0Ra6Vu6I7XuK7tcnyFWJg+becx1RfAR35feWK81sru8TyuldQIt7uAKMA8tqFTP8j1Af7iz7UDokbCCfDNCX1GxdAWgXs+UKpwhO89nsidHAsCkW2lWSEM0E3xtOJDyNFoauiHxBKGKUsApJTnf39H+EW9tWrqN5W2sZg8="
-              },
-              "on_success": "never"
+    "deploy": {
+      "provider": "heroku",
+      "api_key": {
+        "secure": "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
+      },
+      "app": "docs-travis-ci-com",
+      "skip_cleanup": true,
+      "true": {
+        "branch": ["master"]
+      }
+    },
+    "notifications": {
+      "slack": {
+        "rooms": {
+          "secure": "LPNgf0Ra6Vu6I7XuK7tcnyFWJg+becx1RfAR35feWK81sru8TyuldQIt7uAKMA8tqFTP8j1Af7iz7UDokbCCfDNCX1GxdAWgXs+UKpwhO89nsidHAsCkW2lWSEM0E3xtOJDyNFoauiHxBKGKUsApJTnf39H+EW9tWrqN5W2sZg8="
+        },
+        "on_success": "never"
+      },
+      "webhooks": "https://docs.travis-ci.com/update_webhook_payload_doc"
+    },
+    "install": ["rvm use 2.3.1 --install", "bundle install --deployment"],
+    "script": ["bundle exec rake test"],
+    ".result": "configured",
+    "global_env": ["PATH=$HOME/.local/user/bin:$PATH"],
+    "group": "stable"
+  },
+  "type": "cron",
+  "state": "passed",
+  "status": 0,
+  "result": 0,
+  "status_message": "Passed",
+  "result_message": "Passed",
+  "started_at": "2017-10-16T16:08:56Z",
+  "finished_at": "2017-10-16T16:12:35Z",
+  "duration": 219,
+  "build_url": "https://travis-ci.org/travis-ci/docs-travis-ci-com/builds/288639281",
+  "commit_id": 84531696,
+  "commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
+  "base_commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
+  "head_commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
+  "branch": "master",
+  "message": "Merge pull request #1389 from christopher-dG/patch-1\\n\\nJulia: Refer to PkgDev's generate instead of Pkg's",
+  "compare_url": "https://github.com/travis-ci/docs-travis-ci-com/compare/eb58bd2fac2e339d0339689d9eb7290246805a1d...d79e3a6ff0cada29d731ed93de203f76a81d02c0",
+  "committed_at": "2017-10-16T14:56:34Z",
+  "author_name": "Plaindocs",
+  "author_email": "lykoszine@gmail.com",
+  "committer_name": "GitHub",
+  "committer_email": "noreply@github.com",
+  "pull_request": true,
+  "pull_request_number": 123,
+  "pull_request_title": "The title of the pull request",
+  "tag": null,
+  "repository": {
+    "id": 1771959,
+    "name": "docs-travis-ci-com",
+    "owner_name": "travis-ci",
+    "url": "http://docs.travis-ci.com"
+  },
+  "matrix": [
+    {
+      "id": 288639284,
+      "repository_id": 1771959,
+      "parent_id": 288639281,
+      "number": "2843.1",
+      "state": "passed",
+      "config": {
+        "sudo": false,
+        "dist": "trusty",
+        "language": "python",
+        "python": "3.5.2",
+        "branches": {
+          "only": ["master"]
+        },
+        "env": ["TEST_SUITE=integration"],
+        "cache": {
+          "pip": true,
+          "directories": ["vendor/bundle", "node_modules"]
+        },
+        "notifications": {
+          "slack": {
+            "rooms": {
+              "secure": "LPNgf0Ra6Vu6I7XuK7tcnyFWJg+becx1RfAR35feWK81sru8TyuldQIt7uAKMA8tqFTP8j1Af7iz7UDokbCCfDNCX1GxdAWgXs+UKpwhO89nsidHAsCkW2lWSEM0E3xtOJDyNFoauiHxBKGKUsApJTnf39H+EW9tWrqN5W2sZg8="
             },
-            "webhooks": "https://docs.travis-ci.com/update_webhook_payload_doc"
+            "on_success": "never"
           },
-          "install": [
-            "rvm use 2.3.1 --install",
-            "bundle install --deployment"
-          ],
-          "script": [
-            "bundle exec rake test"
-          ],
-          ".result": "configured",
-          "global_env": [
-            "PATH=$HOME/.local/user/bin:$PATH"
-          ],
-          "group": "stable",
-          "os": "linux",
-          "addons": {
-            "deploy": {
-              "provider": "heroku",
-              "api_key": {
-                "secure": "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
-              },
-              "app": "docs-travis-ci-com",
-              "skip_cleanup": true,
-              "true": {
-                "branch": [
-                  "master"
-                ]
-              }
+          "webhooks": "https://docs.travis-ci.com/update_webhook_payload_doc"
+        },
+        "install": ["rvm use 2.3.1 --install", "bundle install --deployment"],
+        "script": ["bundle exec rake test"],
+        ".result": "configured",
+        "global_env": ["PATH=$HOME/.local/user/bin:$PATH"],
+        "group": "stable",
+        "os": "linux",
+        "addons": {
+          "deploy": {
+            "provider": "heroku",
+            "api_key": {
+              "secure": "hylw2GIHMvZKOKX3uPSaLEzVrUGEA9mzGEA0s4zK37W9HJCTnvAcmgRCwOkRuC4L7R4Zshdh/CGORNnBBgh1xx5JGYwkdnqtjHuUQmWEXCusrIURu/iEBNSsZZEPK7zBuwqMHj2yRm64JfbTDJsku3xdoA5Z8XJG5AMJGKLFgUQ="
+            },
+            "app": "docs-travis-ci-com",
+            "skip_cleanup": true,
+            "true": {
+              "branch": ["master"]
             }
           }
-        },
-        "status": 0,
-        "result": 0,
-        "commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
-        "branch": "master",
-        "message": "Merge pull request #1389 from christopher-dG/patch-1\\n\\nJulia: Refer to PkgDev's generate instead of Pkg's",
-        "compare_url": "https://github.com/travis-ci/docs-travis-ci-com/compare/eb58bd2fac2e339d0339689d9eb7290246805a1d...d79e3a6ff0cada29d731ed93de203f76a81d02c0",
-        "started_at": null,
-        "finished_at": null,
-        "committed_at": "2017-10-16T14:56:34Z",
-        "author_name": "Plaindocs",
-        "author_email": "lykoszine@gmail.com",
-        "committer_name": "GitHub",
-        "committer_email": "noreply@github.com",
-        "allow_failure": true
-      }
-    ]
-  }
+        }
+      },
+      "status": 0,
+      "result": 0,
+      "commit": "d79e3a6ff0cada29d731ed93de203f76a81d02c0",
+      "branch": "master",
+      "message": "Merge pull request #1389 from christopher-dG/patch-1\\n\\nJulia: Refer to PkgDev's generate instead of Pkg's",
+      "compare_url": "https://github.com/travis-ci/docs-travis-ci-com/compare/eb58bd2fac2e339d0339689d9eb7290246805a1d...d79e3a6ff0cada29d731ed93de203f76a81d02c0",
+      "started_at": null,
+      "finished_at": null,
+      "committed_at": "2017-10-16T14:56:34Z",
+      "author_name": "Plaindocs",
+      "author_email": "lykoszine@gmail.com",
+      "committer_name": "GitHub",
+      "committer_email": "noreply@github.com",
+      "allow_failure": true
+    }
+  ]
+}

--- a/tests/zeus/api/resources/test_hook_details.py
+++ b/tests/zeus/api/resources/test_hook_details.py
@@ -46,6 +46,7 @@ def test_hook_update(
     assert hook.repository_id == default_repo.id
     assert hook.provider == "travis"
     assert hook.config == {"domain": "api.travis-ci.org"}
+    assert hook.get_provider().get_name(default_hook.config) == "api.travis-ci.org"
 
 
 def test_cannot_update_hook_without_admin(
@@ -67,4 +68,4 @@ def test_hook_update_without_config(
     assert hook.repository_id == default_repo.id
     assert hook.provider == "travis"
     # we're ensuring that the config doesnt get overwritten by the defaults
-    assert hook.config == {"domain": "api.travis-ci.com"}
+    assert hook.config == {"domain": "api.travis-ci.org"}

--- a/tests/zeus/providers/travis/test_base.py
+++ b/tests/zeus/providers/travis/test_base.py
@@ -26,3 +26,15 @@ def test_domain_rejects_random_domain():
     provider = TravisProvider()
     with pytest.raises(ValidationError):
         provider.validate_config({"domain": "example.com"})
+
+
+def test_name_is_domain():
+    provider = TravisProvider()
+    rv = provider.get_name({"domain": "api.travis-ci.example"})
+    assert rv == "api.travis-ci.example"
+
+
+def test_name_defaults_to_travis_org():
+    provider = TravisProvider()
+    rv = provider.get_name({})
+    assert rv == "api.travis-ci.org"

--- a/tests/zeus/providers/travis/test_webhook.py
+++ b/tests/zeus/providers/travis/test_webhook.py
@@ -96,7 +96,7 @@ def test_queued_build(
 ):
     responses.add(
         responses.GET,
-        "https://api.travis-ci.com/config",
+        "https://api.travis-ci.org/config",
         get_config_response(public_key_bytes),
     )
 
@@ -116,7 +116,7 @@ def test_queued_build(
 
     build = (
         Build.query.unrestricted_unsafe()
-        .filter(Build.provider == "travis", Build.external_id == "288639281")
+        .filter(Build.provider == "api.travis-ci.org", Build.external_id == "288639281")
         .first()
     )
     assert build
@@ -130,7 +130,7 @@ def test_queued_build(
 
     job = (
         Job.query.unrestricted_unsafe()
-        .filter(Job.provider == "travis", Job.external_id == "288639284")
+        .filter(Job.provider == "api.travis-ci.org", Job.external_id == "288639284")
         .first()
     )
     assert job
@@ -158,7 +158,7 @@ def test_pull_request(
 ):
     responses.add(
         responses.GET,
-        "https://api.travis-ci.com/config",
+        "https://api.travis-ci.org/config",
         get_config_response(public_key_bytes),
     )
 
@@ -188,7 +188,7 @@ def test_pull_request(
 
     build = (
         Build.query.unrestricted_unsafe()
-        .filter(Build.provider == "travis", Build.external_id == "288639281")
+        .filter(Build.provider == "api.travis-ci.org", Build.external_id == "288639281")
         .first()
     )
     assert build
@@ -202,7 +202,7 @@ def test_pull_request(
 
     job = (
         Job.query.unrestricted_unsafe()
-        .filter(Job.provider == "travis", Job.external_id == "288639284")
+        .filter(Job.provider == "api.travis-ci.org", Job.external_id == "288639284")
         .first()
     )
     assert job

--- a/tests/zeus/web/hooks/test_build_hook.py
+++ b/tests/zeus/web/hooks/test_build_hook.py
@@ -17,14 +17,16 @@ def test_new_build(client, default_source, default_repo, default_hook):
     build = Build.query.unrestricted_unsafe().get(resp.json()["id"])
     assert build
     assert build.repository_id == default_repo.id
-    assert build.provider == default_hook.provider
+    assert build.provider == default_hook.get_provider().get_name(default_hook.config)
     assert build.external_id == build_xid
     assert build.label == "test build"
 
 
 def test_existing_build(client, default_source, default_repo, default_hook):
     build = factories.BuildFactory(
-        source=default_source, provider=default_hook.provider, external_id="2"
+        source=default_source,
+        provider=default_hook.get_provider().get_name(default_hook.config),
+        external_id="2",
     )
 
     path = "/hooks/{}/{}/builds/{}".format(

--- a/tests/zeus/web/hooks/test_job_artifacts_hook.py
+++ b/tests/zeus/web/hooks/test_job_artifacts_hook.py
@@ -6,11 +6,16 @@ from zeus.models import Artifact
 
 def test_new_artifact(client, default_source, default_repo, default_hook, sample_xunit):
     build = factories.BuildFactory(
-        source=default_source, provider=default_hook.provider, external_id="3"
+        source=default_source,
+        provider=default_hook.get_provider().get_name(default_hook.config),
+        external_id="3",
     )
 
     job = factories.JobFactory(
-        build=build, provider=default_hook.provider, external_id="2", in_progress=True
+        build=build,
+        provider=default_hook.get_provider().get_name(default_hook.config),
+        external_id="2",
+        in_progress=True,
     )
 
     path = "/hooks/{}/{}/builds/{}/jobs/{}/artifacts".format(

--- a/tests/zeus/web/hooks/test_job_hook.py
+++ b/tests/zeus/web/hooks/test_job_hook.py
@@ -5,7 +5,9 @@ from zeus.models import Job
 
 def test_new_job(client, default_source, default_repo, default_hook):
     build = factories.BuildFactory(
-        source=default_source, provider=default_hook.provider, external_id="3"
+        source=default_source,
+        provider=default_hook.get_provider().get_name(default_hook.config),
+        external_id="3",
     )
 
     job_xid = "2"
@@ -23,7 +25,7 @@ def test_new_job(client, default_source, default_repo, default_hook):
     assert job
     assert job.build_id == build.id
     assert job.repository_id == build.repository_id
-    assert job.provider == default_hook.provider
+    assert job.provider == default_hook.get_provider().get_name(default_hook.config)
     assert job.external_id == job_xid
     assert job.result == Result.passed
     assert job.status == Status.finished
@@ -31,11 +33,16 @@ def test_new_job(client, default_source, default_repo, default_hook):
 
 def test_existing_job(client, default_source, default_repo, default_hook):
     build = factories.BuildFactory(
-        source=default_source, provider=default_hook.provider, external_id="3"
+        source=default_source,
+        provider=default_hook.get_provider().get_name(default_hook.config),
+        external_id="3",
     )
 
     job = factories.JobFactory(
-        build=build, provider=default_hook.provider, external_id="2", in_progress=True
+        build=build,
+        provider=default_hook.get_provider().get_name(default_hook.config),
+        external_id="2",
+        in_progress=True,
     )
 
     path = "/hooks/{}/{}/builds/{}/jobs/{}".format(

--- a/webapp/pages/RepositoryHookDetails.jsx
+++ b/webapp/pages/RepositoryHookDetails.jsx
@@ -60,18 +60,27 @@ export default class RepositoryHookDetails extends AsyncPage {
     this.api.put(`/hooks/${params.hookId}`, {data});
   };
 
-  onChangeDomain = selected => {
+  onChangeConfig = (key, value) => {
     let {hook} = this.state;
     let {params} = this.props;
 
     let data = {
       config: {
         ...hook.config,
-        domain: selected.value
+        [key]: value
       }
     };
 
-    this.api.put(`/hooks/${params.hookId}`, {data});
+    this.api.put(
+      `/hooks/${params.hookId}`,
+      {data},
+      this.setState({
+        hook: {
+          ...hook,
+          ...data
+        }
+      })
+    );
   };
 
   renderBody() {
@@ -139,9 +148,30 @@ export default class RepositoryHookDetails extends AsyncPage {
                   placeholder=""
                   clearable={false}
                   options={TRAVIS_DOMAIN_OPTIONS}
-                  onChange={this.onChangeDomain}
+                  onChange={({value}) => this.onChangeConfig('domain', value)}
                   value={hook.config.domain || TRAVIS_DOMAIN_OPTIONS[0]}
                 />
+              </OverflowColumn>
+            </Row>
+          )}
+          {hook.provider === 'custom' && (
+            <Row>
+              <Column width={200}>
+                <strong>Service Name</strong>
+              </Column>
+              <OverflowColumn textAlign="left">
+                <div style={{marginBottom: 5}}>
+                  <input
+                    type="text"
+                    placeholder=""
+                    onChange={e => this.onChangeConfig('name', e.target.value)}
+                    value={hook.config.name || 'custom'}
+                  />
+                </div>
+                <div style={{fontSize: '90%'}}>
+                  Enter a service name unique to this provider. It will be captured and
+                  keyed with each reported build.
+                </div>
               </OverflowColumn>
             </Row>
           )}

--- a/webapp/pages/RepositoryHooks.jsx
+++ b/webapp/pages/RepositoryHooks.jsx
@@ -36,32 +36,40 @@ export default class RepositoryHooks extends AsyncPage {
           <SectionHeading>Hooks</SectionHeading>
         </div>
         {hookList.length ? (
-          <ResultGrid>
-            <div>
-              <Header>
-                <Column>ID</Column>
-                <Column width={120}>Provider</Column>
-                <Column width={120}>Required?</Column>
-                <Column width={150}>Created</Column>
-              </Header>
-              {hookList.map(hook => {
-                return (
-                  <Row key={hook.id}>
-                    <Column>
-                      <Link to={`/${repo.full_name}/settings/hooks/${hook.id}`}>
-                        {hook.id}
-                      </Link>
-                    </Column>
-                    <Column width={120}>{hook.provider}</Column>
-                    <Column width={120}>{hook.is_required ? 'Yes' : 'No'}</Column>
-                    <Column width={150}>
-                      <TimeSince date={hook.created_at} />
-                    </Column>
-                  </Row>
-                );
-              })}
-            </div>
-          </ResultGrid>
+          <React.Fragment>
+            <ResultGrid>
+              <div>
+                <Header>
+                  <Column>ID</Column>
+                  <Column width={120}>Name</Column>
+                  <Column width={120}>Provider</Column>
+                  <Column width={120}>Required?</Column>
+                  <Column width={150}>Created</Column>
+                </Header>
+                {hookList.map(hook => {
+                  return (
+                    <Row key={hook.id}>
+                      <Column>
+                        <Link to={`/${repo.full_name}/settings/hooks/${hook.id}`}>
+                          {hook.id}
+                        </Link>
+                      </Column>
+                      <Column width={120}>{hook.provider_name}</Column>
+                      <Column width={120}>{hook.provider}</Column>
+                      <Column width={120}>{hook.is_required ? 'Yes' : 'No'}</Column>
+                      <Column width={150}>
+                        <TimeSince date={hook.created_at} />
+                      </Column>
+                    </Row>
+                  );
+                })}
+              </div>
+            </ResultGrid>
+            <p>
+              Each build that&apos;s reported via a hook is keyed based on the provider
+              name and the external_id.
+            </p>
+          </React.Fragment>
         ) : (
           <div>
             <p>

--- a/zeus/models/hook.py
+++ b/zeus/models/hook.py
@@ -27,7 +27,7 @@ class Hook(RepositoryBoundMixin, StandardAttributes, db.Model):
     config = db.Column(JSONEncodedDict, nullable=True)
 
     __tablename__ = "hook"
-    __repr__ = model_repr("repository_id")
+    __repr__ = model_repr("repository_id", "provider")
 
     @classmethod
     def generate_token(cls) -> bytes:
@@ -40,6 +40,11 @@ class Hook(RepositoryBoundMixin, StandardAttributes, db.Model):
 
     def is_valid_signature(self, signature: bytes) -> bool:
         return compare_digest(self.get_signature(), signature)
+
+    def get_provider(self):
+        from zeus.providers import get_provider
+
+        return get_provider(self.provider)
 
     @classmethod
     def get_required_hook_ids(cls, repository_id: str) -> List[str]:

--- a/zeus/providers/__init__.py
+++ b/zeus/providers/__init__.py
@@ -1,0 +1,19 @@
+from .custom import CustomProvider
+from .travis import TravisProvider
+
+ALIASES = {"travis-ci": "travis"}
+
+PROVIDERS = {"travis": TravisProvider, "custom": CustomProvider}
+
+VALID_PROVIDER_NAMES = tuple(set(PROVIDERS.keys()).union(ALIASES.keys()))
+
+
+class InvalidProvider(Exception):
+    pass
+
+
+def get_provider(provider_name):
+    try:
+        return PROVIDERS[ALIASES.get(provider_name, provider_name)]()
+    except KeyError:
+        raise InvalidProvider(provider_name)

--- a/zeus/providers/base.py
+++ b/zeus/providers/base.py
@@ -33,6 +33,9 @@ class Provider(object):
             "required": [],
         }
 
+    def get_name(self, config):
+        raise NotImplementedError
+
     def validate_config(self, data):
         schema = self.get_config()
         schema["type"] = "object"

--- a/zeus/providers/custom.py
+++ b/zeus/providers/custom.py
@@ -3,4 +3,7 @@ from zeus.providers.base import Provider
 
 class CustomProvider(Provider):
     def get_config(self):
-        return {"properties": {}, "required": []}
+        return {"properties": {"name": {"type": "string"}}, "required": ["name"]}
+
+    def get_name(self, config):
+        return config.get("name", "custom")

--- a/zeus/providers/travis/base.py
+++ b/zeus/providers/travis/base.py
@@ -13,3 +13,6 @@ class TravisProvider(Provider):
             },
             "required": ["domain"],
         }
+
+    def get_name(self, config):
+        return config.get("domain", "api.travis-ci.org")

--- a/zeus/testutils/fixtures.py
+++ b/zeus/testutils/fixtures.py
@@ -187,7 +187,7 @@ def default_api_token():
 
 @pytest.fixture(scope="function")
 def default_hook(default_repo):
-    return factories.HookFactory(repository=default_repo, travis_com=True)
+    return factories.HookFactory(repository=default_repo, travis_org=True)
 
 
 @pytest.fixture(scope="session")

--- a/zeus/web/hooks/job.py
+++ b/zeus/web/hooks/job.py
@@ -8,8 +8,9 @@ from .base import BaseHook
 
 class JobHook(BaseHook):
     def post(self, hook, build_xid, job_xid):
+        provider_name = hook.get_provider().get_name(hook.config)
         build = Build.query.filter(
-            Build.provider == hook.provider, Build.external_id == build_xid
+            Build.provider == provider_name, Build.external_id == build_xid
         ).first()
         if not build:
             return self.respond("", 404)

--- a/zeus/web/hooks/job_artifacts.py
+++ b/zeus/web/hooks/job_artifacts.py
@@ -8,14 +8,15 @@ from .base import BaseHook
 
 class JobArtifactsHook(BaseHook):
     def post(self, hook, build_xid, job_xid):
+        provider_name = hook.get_provider().get_name(hook.config)
         build = Build.query.filter(
-            Build.provider == hook.provider, Build.external_id == build_xid
+            Build.provider == provider_name, Build.external_id == build_xid
         ).first()
         if not build:
             return self.respond("", 404)
 
         job = Job.query.filter(
-            Job.provider == hook.provider,
+            Job.provider == provider_name,
             Job.external_id == job_xid,
             Job.build_id == build.id,
         ).first()


### PR DESCRIPTION
This will make 'custom' hooks require a name, with the migration path being to fall back to 'custom' as the name for now.