### PR TITLE
fix handling of webpack stats files with non-js assets

### DIFF
--- a/zeus/artifacts/webpack.py
+++ b/zeus/artifacts/webpack.py
@@ -38,6 +38,9 @@ class WebpackStatsHandler(ArtifactHandler):
 
                     complete = set()
                     for asset_name in asset_list:
+                        # skip non-js assets like .css files
+                        if asset_index.get(asset_name) is None:
+                            continue
                         # dont track sourcemaps
                         if asset_name.endswith(".map"):
                             continue


### PR DESCRIPTION
The `assetByChunkName` key of the stats file can include non js assets like `static/css/main.900e26e0.css` and `static/css/main.900e26e0.css.map`. The problem in the existing logic is that we expect the `assets` key to have the same items as `assetByChunkName`, which is not the case for non-js assets.

This change skips assets in the `assets` key that do not exist in `assetByChunkName`

Fixes #176