### PR TITLE
ref: Upgrade sentry sdk

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -196,6 +196,7 @@ tenacity = "*"
 reference = "c5269838b0daf49e34cff85e6ad0c7b95dceaf12"
 type = "git"
 url = "https://github.com/sibson/redbeat.git"
+
 [[package]]
 category = "main"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -983,7 +984,7 @@ description = "Python client for Sentry (https://getsentry.com)"
 name = "sentry-sdk"
 optional = false
 python-versions = "*"
-version = "0.7.6"
+version = "0.7.7"
 
 [package.dependencies]
 certifi = "*"
@@ -1228,7 +1229,7 @@ requests = ["6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b", 
 requests-oauthlib = ["50a8ae2ce8273e384895972b56193c7409601a66d4975774c60c2aed869639ca", "883ac416757eada6d3d07054ec7092ac21c7f35cb1d2cf82faf205637081f468"]
 responses = ["98e1c0eb5a7a03d59e73c8ac774428664f319ef35c6ac59479436bbb9c3499be", "a64029dbc6bed7133e2c971ee52153f30e779434ad55a5abf40322bcff91d029"]
 rsa = ["14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66", "1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487"]
-sentry-sdk = ["dc207c083604bae01761866b3145ca9dcf5a45f3de048c4da22eac88889d49e7", "f94cca2eb41d29fd2bdbedaf9d9a262ab3b4660e5d648d9920fae262e240c368"]
+sentry-sdk = ["4250f4d2114d1f45d8a94f2f078016b7d8ffc6f57f42db7f20dccd7692bc804c", "c5a41eba2d27416c81c901fe86de887e356aec4df7afd3327c324b2b3db7e934"]
 simplegeneric = ["dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173"]
 six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
 sqlalchemy = ["8027fa183f5be466030617a497b2d64e0e16c8d615e5a34bdf9fab6f66bf4723"]


### PR DESCRIPTION
This should take care of capturing celery worker crashes