### PR TITLE
ref: Improve concurrency behavior in aggregate_build_stats

### DIFF
--- a/tests/zeus/tasks/test_cleanup_builds.py
+++ b/tests/zeus/tasks/test_cleanup_builds.py
@@ -16,6 +16,7 @@ def test_cleanup_builds(mocker, db_session, default_build, default_revision):
     # prevent resolve_ref
     default_build.revision_sha = default_revision.sha
     default_build.status = Status.in_progress
+    default_build.date_started = job.date_started
     db_session.add(default_build)
     db_session.flush()
 

--- a/zeus/tasks/aggregate_job_stats.py
+++ b/zeus/tasks/aggregate_job_stats.py
@@ -275,7 +275,7 @@ def aggregate_build_stats(build_id: UUID):
     """
     # now we pull in the entirety of the build's data to aggregate state upward
     lock_key = "build:{build_id}".format(build_id=build_id)
-    with redis.lock(lock_key):
+    with redis.lock(lock_key, expire=60, nowait=True):
         build = (
             Build.query.unrestricted_unsafe().with_for_update(nowait=True).get(build_id)
         )

--- a/zeus/tasks/cleanup_builds.py
+++ b/zeus/tasks/cleanup_builds.py
@@ -74,6 +74,7 @@ def cleanup_build_stats(task_limit=100):
         Build.query.unrestricted_unsafe()
         .filter(
             Build.status != Status.finished,
+            Build.date_started < timezone.now() - timedelta(minutes=15),
             ~Job.query.filter(
                 Job.build_id == Build.id, Job.status != Status.finished
             ).exists(),


### PR DESCRIPTION
This will limit the effect of cleanup_builds (minor effect), and adjust the lock to have an expiration window the same as the task, as well as to fail immediately (to avoid blocking the worker).

bors r+