### PR TITLE
fix: Call xhr.send after setting up callback

### DIFF
--- a/webapp/api.jsx
+++ b/webapp/api.jsx
@@ -53,7 +53,6 @@ export class Request {
       xhr.setRequestHeader(key, params.headers[key]);
     });
 
-
     xhr.onreadystatechange = () => {
       if (xhr.readyState === Request.DONE) {
         let responseData = this.processResponseText(xhr);

--- a/webapp/api.jsx
+++ b/webapp/api.jsx
@@ -52,7 +52,7 @@ export class Request {
     Object.keys(params.headers || {}).forEach(key => {
       xhr.setRequestHeader(key, params.headers[key]);
     });
-    xhr.send(params.data ? JSON.stringify(params.data) : null);
+
 
     xhr.onreadystatechange = () => {
       if (xhr.readyState === Request.DONE) {
@@ -84,6 +84,8 @@ export class Request {
         }
       }
     };
+
+    xhr.send(params.data ? JSON.stringify(params.data) : null);
   }
 
   processResponseText(xhr) {


### PR DESCRIPTION
We patch XHR globally in the `send` method and we use it to determine if a request is finished or not.

If you call `send` before, and then hard overwrite `xhr.onreadystatechange` our SDK never picks up finished XHRs.

Examples here always call send after the callback is set
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send
and I think this is a misusage of the API.

Also, your callback would have just been invoked after the first call.
Talked to Kamil, not sure if we can work around this, maybe we can add a warning to the Integration to at least notify users that they did something wrong.