### PR TITLE
feat: Increase LRU cache size for revisions to 100k items

### DIFF
--- a/zeus/vcs/server.py
+++ b/zeus/vcs/server.py
@@ -10,7 +10,7 @@ from zeus.utils.sentry import span
 from .api import register_api_routes
 from .utils import save_revision
 
-_revision_cache = LRU(1000)
+_revision_cache = LRU(100000)
 
 
 @span("worker")


### PR DESCRIPTION
Some basic tests suggest this will add anywhere from 10mb to 90mb per process, but can save us a very large amount of processing time if there are a larger number of repositories causing evictions.