### PR TITLE
Revert "ref: Extend build timeout to 20m"

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,6 @@ steps:
     '-t', 'gcr.io/$PROJECT_ID/zeus:latest',
     '.'
   ]
-  timeout: 1200s
 images:
 - 'gcr.io/$PROJECT_ID/zeus:$COMMIT_SHA'
 - 'gcr.io/$PROJECT_ID/zeus:latest'


### PR DESCRIPTION
Google has a maximum of 10 minutes. On to the next solution!

bors r+

This reverts commit 0c94004b134b20940e2b49cfbd0e42cd65df03f7.