### PR TITLE
ref: Lock resolve_ref tasks to avoid duplicate failures

### DIFF
--- a/zeus/tasks/resolve_ref.py
+++ b/zeus/tasks/resolve_ref.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from zeus import auth
 from zeus.api.schemas import BuildSchema
-from zeus.config import celery, db
+from zeus.config import celery, db, redis
 from zeus.constants import Result, Status
 from zeus.exceptions import InvalidPublicKey, UnknownRevision
 from zeus.models import Build, ChangeRequest, FailureReason, Revision
@@ -16,13 +16,19 @@ build_schema = BuildSchema()
 
 @celery.task(max_retries=5, autoretry_for=(Exception,), acks_late=True, time_limit=60)
 def resolve_ref_for_build(build_id: UUID):
-    build = Build.query.unrestricted_unsafe().get(build_id)
-    if not build:
-        raise ValueError("Unable to find build with id = {}".format(build_id))
+    lock_key = f"resolve-build-ref:{build_id}"
+    with redis.lock(lock_key):
+        build = Build.query.unrestricted_unsafe().get(build_id)
+        if not build:
+            raise ValueError("Unable to find build with id = {}".format(build_id))
 
-    auth.set_current_tenant(auth.RepositoryTenant(repository_id=build.repository_id))
+        if build.revision_sha:
+            return
 
-    if not build.revision_sha:
+        auth.set_current_tenant(
+            auth.RepositoryTenant(repository_id=build.repository_id)
+        )
+
         revision: Optional[Revision] = None
         try:
             revision = revisions.identify_revision(
@@ -50,37 +56,39 @@ def resolve_ref_for_build(build_id: UUID):
         db.session.add(build)
         db.session.commit()
 
-        data = build_schema.dump(build)
-        publish("builds", "build.update", data)
+    data = build_schema.dump(build)
+    publish("builds", "build.update", data)
 
 
 @celery.task(max_retries=5, autoretry_for=(Exception,), acks_late=True, time_limit=60)
 def resolve_ref_for_change_request(change_request_id: UUID):
-    cr = ChangeRequest.query.unrestricted_unsafe().get(change_request_id)
-    if not cr:
-        raise ValueError(
-            "Unable to find change request with id = {}".format(change_request_id)
-        )
-
-    auth.set_current_tenant(auth.RepositoryTenant(repository_id=cr.repository_id))
-
-    if not cr.parent_revision_sha and cr.parent_ref:
-        try:
-            revision = revisions.identify_revision(
-                cr.repository, cr.parent_ref, with_vcs=True
+    lock_key = f"resolve-cr-ref:{change_request_id}"
+    with redis.lock(lock_key):
+        cr = ChangeRequest.query.unrestricted_unsafe().get(change_request_id)
+        if not cr:
+            raise ValueError(
+                "Unable to find change request with id = {}".format(change_request_id)
             )
-        except InvalidPublicKey:
-            raise
-        cr.parent_revision_sha = revision.sha
-        db.session.add(cr)
-        db.session.commit()
 
-    if not cr.head_revision_sha and cr.head_ref:
-        revision = revisions.identify_revision(
-            cr.repository, cr.head_ref, with_vcs=True
-        )
-        cr.head_revision_sha = revision.sha
-        if not cr.authors and revision.authors:
-            cr.authors = revision.authors
-        db.session.add(cr)
-        db.session.commit()
+        auth.set_current_tenant(auth.RepositoryTenant(repository_id=cr.repository_id))
+
+        if not cr.parent_revision_sha and cr.parent_ref:
+            try:
+                revision = revisions.identify_revision(
+                    cr.repository, cr.parent_ref, with_vcs=True
+                )
+            except InvalidPublicKey:
+                raise
+            cr.parent_revision_sha = revision.sha
+            db.session.add(cr)
+            db.session.commit()
+
+        if not cr.head_revision_sha and cr.head_ref:
+            revision = revisions.identify_revision(
+                cr.repository, cr.head_ref, with_vcs=True
+            )
+            cr.head_revision_sha = revision.sha
+            if not cr.authors and revision.authors:
+                cr.authors = revision.authors
+            db.session.add(cr)
+            db.session.commit()


### PR DESCRIPTION
This resolves a race condition which was causing duplicate FailureReason's to end up in the database for unresolvable_ref. A follow up will be needed to cleanup the bad data and add an additional constraint.

bors r+