### PR TITLE
fix: Add constraint on build-specific failures

### DIFF
--- a/zeus/factories/failurereason.py
+++ b/zeus/factories/failurereason.py
@@ -32,3 +32,6 @@ class FailureReasonFactory(ModelFactory):
         no_jobs = factory.Trait(
             reason=models.FailureReason.Reason.no_jobs, job=None, job_id=None
         )
+        unresolvable_ref = factory.Trait(
+            reason=models.FailureReason.Reason.unresolvable_ref, job=None, job_id=None
+        )

--- a/zeus/migrations/e373a7bffa18_unique_build_failures.py
+++ b/zeus/migrations/e373a7bffa18_unique_build_failures.py
@@ -1,0 +1,42 @@
+"""unique_build_failures
+
+Revision ID: e373a7bffa18
+Revises: 54bbb66a65a6
+Create Date: 2020-03-13 09:25:38.492704
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e373a7bffa18"
+down_revision = "54bbb66a65a6"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    # first we clean up duplicate rows
+    connection = op.get_bind()
+    connection.execute(
+        """
+        DELETE FROM failurereason a
+        USING failurereason b
+        WHERE a.id > b.id
+        AND a.reason = b.reason
+        AND a.build_id = b.build_id
+        """
+    )
+
+    op.create_index(
+        "unq_failurereason_buildonly",
+        "failurereason",
+        ["build_id", "reason"],
+        unique=True,
+        postgresql_where=sa.text("job_id IS NULL"),
+    )
+
+
+def downgrade():
+    op.drop_index("unq_failurereason_buildonly", table_name="failurereason")

--- a/zeus/models/failurereason.py
+++ b/zeus/models/failurereason.py
@@ -9,14 +9,6 @@ from zeus.db.utils import model_repr
 
 
 class FailureReason(RepositoryBoundMixin, StandardAttributes, db.Model):
-    __tablename__ = "failurereason"
-    __table_args__ = (
-        db.UniqueConstraint(
-            "build_id", "job_id", "reason", name="unq_failurereason_key"
-        ),
-    )
-    __repr__ = model_repr("reason")
-
     class Reason(enum.Enum):
         failing_tests = "failing_tests"
         missing_tests = "missing_tests"
@@ -31,3 +23,18 @@ class FailureReason(RepositoryBoundMixin, StandardAttributes, db.Model):
 
     build = db.relationship("Build")
     job = db.relationship("Job")
+
+    __tablename__ = "failurereason"
+    __table_args__ = (
+        db.UniqueConstraint(
+            "build_id", "job_id", "reason", name="unq_failurereason_key"
+        ),
+        db.Index(
+            "unq_failurereason_buildonly",
+            build_id,
+            reason,
+            unique=True,
+            postgresql_where=job_id.is_(None),
+        ),
+    )
+    __repr__ = model_repr("reason")


### PR DESCRIPTION
This adds a unique constraint on FailureReason(build_id, reason) WHERE job_id IS NULL.

bors r+