### PR TITLE
ref: Add celery.delay abstraction to centralize task management

### DIFF
--- a/tests/zeus/api/resources/test_github_repositories.py
+++ b/tests/zeus/api/resources/test_github_repositories.py
@@ -76,7 +76,7 @@ def test_new_repository_github(
 def test_deactivate_repository_github(
     client, mocker, default_login, default_repo, default_repo_access
 ):
-    mock_delete_repo = mocker.patch("zeus.tasks.delete_repo.delay")
+    mock_delay = mocker.patch("zeus.config.celery.delay")
 
     resp = client.delete(
         "/api/github/repos",
@@ -84,7 +84,7 @@ def test_deactivate_repository_github(
     )
 
     assert resp.status_code == 202
-    mock_delete_repo.assert_called_once_with(repo_id=default_repo.id)
+    mock_delay.assert_called_once_with("zeus.delete_repo", repo_id=default_repo.id)
 
 
 def test_deactivate_non_existing_repository_github(client, default_login):

--- a/tests/zeus/api/resources/test_job_details.py
+++ b/tests/zeus/api/resources/test_job_details.py
@@ -23,7 +23,7 @@ def test_update_job_to_finished(
 ):
     job = factories.JobFactory(build=default_build, in_progress=True)
 
-    mock_delay = mocker.patch("zeus.tasks.aggregate_build_stats_for_job.delay")
+    mock_delay = mocker.patch("zeus.config.celery.delay")
 
     resp = client.put(
         "/api/repos/{}/builds/{}/jobs/{}".format(
@@ -45,7 +45,9 @@ def test_update_job_to_finished(
     assert job.date_started == datetime(2017, 1, 1, 1, 2, 30, tzinfo=timezone.utc)
     assert job.date_finished == datetime(2017, 1, 1, 1, 22, 30, tzinfo=timezone.utc)
 
-    mock_delay.assert_called_once_with(job_id=job.id)
+    mock_delay.assert_called_once_with(
+        "zeus.aggregate_build_stats_for_job", job_id=job.id
+    )
 
 
 def test_update_job_to_in_progress(
@@ -53,7 +55,7 @@ def test_update_job_to_in_progress(
 ):
     job = factories.JobFactory(build=default_build, queued=True)
 
-    mock_delay = mocker.patch("zeus.tasks.aggregate_build_stats_for_job.delay")
+    mock_delay = mocker.patch("zeus.config.celery.delay")
 
     resp = client.put(
         "/api/repos/{}/builds/{}/jobs/{}".format(
@@ -69,7 +71,9 @@ def test_update_job_to_in_progress(
     assert job.date_started
     assert not job.date_finished
 
-    mock_delay.assert_called_once_with(job_id=job.id)
+    mock_delay.assert_called_once_with(
+        "zeus.aggregate_build_stats_for_job", job_id=job.id
+    )
 
 
 def test_update_job_to_finished_with_pending_artifacts(
@@ -85,7 +89,7 @@ def test_update_job_to_finished_with_pending_artifacts(
 
     assert default_job.result != Result.failed
 
-    mock_delay = mocker.patch("zeus.tasks.aggregate_build_stats_for_job.delay")
+    mock_delay = mocker.patch("zeus.config.celery.delay")
 
     resp = client.put(
         "/api/repos/{}/builds/{}/jobs/{}".format(
@@ -101,7 +105,9 @@ def test_update_job_to_finished_with_pending_artifacts(
     assert default_job.status == Status.collecting_results
     assert default_job.result == Result.failed
 
-    mock_delay.assert_called_once_with(job_id=default_job.id)
+    mock_delay.assert_called_once_with(
+        "zeus.aggregate_build_stats_for_job", job_id=default_job.id
+    )
 
 
 def test_update_job_restart(
@@ -109,7 +115,7 @@ def test_update_job_restart(
 ):
     job = factories.JobFactory(build=default_build, finished=True, passed=True)
 
-    mock_delay = mocker.patch("zeus.tasks.aggregate_build_stats_for_job.delay")
+    mock_delay = mocker.patch("zeus.config.celery.delay")
 
     resp = client.put(
         "/api/repos/{}/builds/{}/jobs/{}".format(
@@ -126,4 +132,6 @@ def test_update_job_restart(
     assert job.date_started
     assert not job.date_finished
 
-    mock_delay.assert_called_once_with(job_id=job.id)
+    mock_delay.assert_called_once_with(
+        "zeus.aggregate_build_stats_for_job", job_id=job.id
+    )

--- a/tests/zeus/api/resources/test_repository_details.py
+++ b/tests/zeus/api/resources/test_repository_details.py
@@ -50,12 +50,12 @@ def test_cannot_update_without_admin(
 def test_delete_repository(
     client, mocker, default_login, default_repo, default_repo_access
 ):
-    mock_delete_repo = mocker.patch("zeus.tasks.delete_repo.delay")
+    mock_delay = mocker.patch("zeus.config.celery.delay")
 
     resp = client.delete("/api/repos/{}".format(default_repo.get_full_name()))
 
     assert resp.status_code == 202
-    mock_delete_repo.assert_called_once_with(repo_id=default_repo.id)
+    mock_delay.assert_called_once_with("zeus.delete_repo", repo_id=default_repo.id)
 
     default_repo = Repository.query.get(default_repo.id)
     assert default_repo.status == RepositoryStatus.inactive
@@ -74,9 +74,9 @@ def test_delete_inactive_repository(
     db_session.add(default_repo)
     db_session.flush()
 
-    mock_delete_repo = mocker.patch("zeus.tasks.delete_repo.delay")
+    mock_delay = mocker.patch("zeus.config.celery.delay")
 
     resp = client.delete("/api/repos/{}".format(default_repo.get_full_name()))
 
     assert resp.status_code == 202
-    assert not mock_delete_repo.mock_calls
+    assert not mock_delay.mock_calls

--- a/tests/zeus/tasks/test_aggregate_job_stats.py
+++ b/tests/zeus/tasks/test_aggregate_job_stats.py
@@ -28,16 +28,16 @@ def test_finished_job(mocker, db_session, default_revision, default_tenant):
     job = factories.JobFactory(build=build, failed=True)
     db_session.add(job)
 
-    mock_send_build_notifications = mocker.patch(
-        "zeus.tasks.send_build_notifications.delay"
-    )
+    mock_delay = mocker.patch("zeus.config.celery.delay")
 
     aggregate_build_stats(build.id)
 
     assert build.status == Status.finished
     assert build.result == Result.failed
 
-    mock_send_build_notifications.assert_called_once_with(build_id=build.id)
+    mock_delay.assert_called_once_with(
+        "zeus.send_build_notifications", build_id=build.id
+    )
 
 
 def test_no_jobs(mocker, db_session, default_revision, default_tenant):

--- a/tests/zeus/tasks/test_deactivate_repo.py
+++ b/tests/zeus/tasks/test_deactivate_repo.py
@@ -1,5 +1,6 @@
+from zeus.constants import DeactivationReason
 from zeus.models import ItemOption, RepositoryStatus
-from zeus.tasks import deactivate_repo, DeactivationReason
+from zeus.tasks import deactivate_repo
 
 
 def test_deactivate_repo(

--- a/zeus/api/resources/build_jobs.py
+++ b/zeus/api/resources/build_jobs.py
@@ -1,10 +1,9 @@
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import subqueryload_all
 
-from zeus.config import db
+from zeus.config import celery, db
 from zeus.constants import Status
 from zeus.models import Build, Job
-from zeus.tasks import aggregate_build_stats_for_job
 from zeus.utils import timezone
 
 from .base_build import BaseBuildResource
@@ -43,6 +42,6 @@ class BuildJobsResource(BaseBuildResource):
             db.session.rollback()
             return self.respond(status=422)
 
-        aggregate_build_stats_for_job.delay(job_id=job.id)
+        celery.delay("zeus.aggregate_build_stats_for_job", job_id=job.id)
 
         return self.respond_with_schema(job_schema, job)

--- a/zeus/api/resources/change_request_details.py
+++ b/zeus/api/resources/change_request_details.py
@@ -1,4 +1,4 @@
-from zeus.config import db
+from zeus.config import celery, db
 from zeus.models import ChangeRequest
 
 from .base_change_request import BaseChangeRequestResource
@@ -23,8 +23,6 @@ class ChangeRequestDetailsResource(BaseChangeRequestResource):
             db.session.commit()
 
         if not cr.parent_revision_sha or (not cr.head_revision_sha and cr.head_ref):
-            from zeus.tasks import resolve_ref_for_change_request
-
-            resolve_ref_for_change_request.delay(change_request_id=cr.id)
+            celery.delay("zeus.resolve_ref_for_change_request", change_request_id=cr.id)
 
         return self.respond_with_schema(schema, cr)

--- a/zeus/api/resources/job_artifacts.py
+++ b/zeus/api/resources/job_artifacts.py
@@ -7,10 +7,9 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 from werkzeug.datastructures import FileStorage
 
-from zeus.config import db
+from zeus.config import celery, db
 from zeus.constants import Result, Status
 from zeus.models import Artifact, Job
-from zeus.tasks import process_artifact
 
 from .base_job import BaseJobResource
 from ..schemas import ArtifactSchema
@@ -105,6 +104,6 @@ class JobArtifactsResource(BaseJobResource):
         db.session.add(artifact)
         db.session.commit()
 
-        process_artifact.delay(artifact_id=artifact.id)
+        celery.delay("zeus.process_artifact", artifact_id=artifact.id)
 
         return self.respond_with_schema(artifact_schema, artifact, 201)

--- a/zeus/api/resources/job_details.py
+++ b/zeus/api/resources/job_details.py
@@ -1,7 +1,6 @@
-from zeus.config import db
+from zeus.config import celery, db
 from zeus.constants import Result, Status
 from zeus.models import Job
-from zeus.tasks import aggregate_build_stats_for_job
 from zeus.utils import timezone
 from zeus.utils.artifacts import has_unprocessed_artifacts
 
@@ -65,6 +64,6 @@ class JobDetailsResource(BaseJobResource):
             db.session.add(job)
             db.session.commit()
 
-        aggregate_build_stats_for_job.delay(job_id=job.id)
+        celery.delay("zeus.aggregate_build_stats_for_job", job_id=job.id)
 
         return self.respond_with_schema(job_schema, job)

--- a/zeus/api/resources/repository_builds.py
+++ b/zeus/api/resources/repository_builds.py
@@ -3,7 +3,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload, subqueryload_all
 
 from zeus import auth
-from zeus.config import db
+from zeus.config import celery, db
 from zeus.models import Author, Build, Email, Repository, User
 from zeus.pubsub.utils import publish
 
@@ -70,9 +70,7 @@ class RepositoryBuildsResource(BaseRepositoryResource):
             raise
 
         if not build.revision_sha:
-            from zeus.tasks import resolve_ref_for_build
-
-            resolve_ref_for_build.delay(build_id=build.id)
+            celery.delay("zeus.resolve_ref_for_build", build_id=build.id)
 
         build_schema.validate(build)
         data = build_schema.dump(build)

--- a/zeus/api/resources/repository_change_requests.py
+++ b/zeus/api/resources/repository_change_requests.py
@@ -1,6 +1,6 @@
 from sqlalchemy.exc import IntegrityError
 
-from zeus.config import db
+from zeus.config import celery, db
 from zeus.models import Repository
 
 from .base_repository import BaseRepositoryResource
@@ -29,9 +29,7 @@ class RepositoryChangeRequestsResource(BaseRepositoryResource):
             raise
 
         if not cr.parent_revision_sha or (not cr.head_revision_sha and cr.head_ref):
-            from zeus.tasks import resolve_ref_for_change_request
-
-            resolve_ref_for_change_request.delay(change_request_id=cr.id)
+            celery.delay("zeus.resolve_ref_for_change_request", change_request_id=cr.id)
 
         schema = ChangeRequestSchema()
         return self.respond_with_schema(schema, cr, status=201)

--- a/zeus/api/resources/repository_details.py
+++ b/zeus/api/resources/repository_details.py
@@ -1,8 +1,7 @@
 from zeus import auth
-from zeus.config import db
+from zeus.config import celery, db
 from zeus.constants import Permission
 from zeus.models import Repository, RepositoryStatus
-from zeus.tasks import delete_repo
 
 from .base_repository import BaseRepositoryResource
 from ..schemas import RepositorySchema
@@ -48,6 +47,6 @@ class RepositoryDetailsResource(BaseRepositoryResource):
             db.session.add(repo)
             db.session.flush()
 
-            delete_repo.delay(repo_id=repo.id)
+            celery.delay("zeus.delete_repo", repo_id=repo.id)
 
         return self.respond(status=202)

--- a/zeus/constants.py
+++ b/zeus/constants.py
@@ -1,6 +1,6 @@
 import zeus
 
-from enum import IntEnum, IntFlag
+from enum import Enum, IntEnum, IntFlag
 
 
 class Status(IntEnum):
@@ -46,6 +46,10 @@ class Permission(IntFlag):
 
     def __str__(self):
         return self.name
+
+
+class DeactivationReason(Enum):
+    invalid_pubkey = "invalid_pubkey"
 
 
 STATUS_PRIORITY = (

--- a/zeus/tasks/cleanup_pending_artifacts.py
+++ b/zeus/tasks/cleanup_pending_artifacts.py
@@ -7,8 +7,6 @@ from zeus.exceptions import UnknownJob
 from zeus.models import Build, PendingArtifact
 from zeus.utils import timezone
 
-from .process_pending_artifact import process_pending_artifact
-
 
 @celery.task(name="zeus.cleanup_pending_artifacts", time_limit=300)
 def cleanup_pending_artifacts(task_limit=100):
@@ -45,7 +43,7 @@ def cleanup_pending_artifacts(task_limit=100):
             "cleanup: process_pending_artifact %s [build_finished]", result.id
         )
         try:
-            process_pending_artifact(pending_artifact_id=result.id)
+            celery.delay("zeus.process_pending_artifact", pending_artifact_id=result.id)
         except UnknownJob:
             # do we just axe it?
             pass

--- a/zeus/tasks/process_travis_webhook.py
+++ b/zeus/tasks/process_travis_webhook.py
@@ -39,7 +39,13 @@ def get_result(state: str) -> str:
     }.get(state, "unknown")
 
 
-@celery.task(max_retries=5, autoretry_for=(Exception,), acks_late=True, time_limit=60)
+@celery.task(
+    name="zeus.process_travis_webhook",
+    max_retries=5,
+    autoretry_for=(Exception,),
+    acks_late=True,
+    time_limit=60,
+)
 def process_travis_webhook(hook_id: str, payload: dict, timestamp_ms: int):
     # TODO(dcramer): we want to utilize timestamp_ms to act as a version and
     # ensure we dont process older updates after newer updates are already present

--- a/zeus/tasks/resolve_ref.py
+++ b/zeus/tasks/resolve_ref.py
@@ -15,7 +15,13 @@ from zeus.utils import revisions
 build_schema = BuildSchema()
 
 
-@celery.task(max_retries=5, autoretry_for=(Exception,), acks_late=True, time_limit=60)
+@celery.task(
+    name="zeus.resolve_ref_for_build",
+    max_retries=5,
+    autoretry_for=(Exception,),
+    acks_late=True,
+    time_limit=60,
+)
 def resolve_ref_for_build(build_id: UUID):
     lock_key = f"resolve-build-ref:{build_id}"
     with redis.lock(lock_key, timeout=60.0, nowait=True):
@@ -68,7 +74,13 @@ def resolve_ref_for_build(build_id: UUID):
     publish("builds", "build.update", data)
 
 
-@celery.task(max_retries=5, autoretry_for=(Exception,), acks_late=True, time_limit=60)
+@celery.task(
+    name="zeus.resolve_ref_for_change_request",
+    max_retries=5,
+    autoretry_for=(Exception,),
+    acks_late=True,
+    time_limit=60,
+)
 def resolve_ref_for_change_request(change_request_id: UUID):
     lock_key = f"resolve-cr-ref:{change_request_id}"
     with redis.lock(lock_key, timeout=60.0, nowait=True):

--- a/zeus/tasks/send_build_notifications.py
+++ b/zeus/tasks/send_build_notifications.py
@@ -11,9 +11,7 @@ from zeus.utils import timezone
 
 
 @celery.task(
-    name="zeus.tasks.send_build_notifications",
-    max_retries=None,
-    autoretry_for=(Exception,),
+    name="zeus.send_build_notifications", max_retries=None, autoretry_for=(Exception,)
 )
 def send_build_notifications(build_id: UUID, time_limit=30):
     build = Build.query.unrestricted_unsafe().get(build_id)

--- a/zeus/tasks/sync_github_access.py
+++ b/zeus/tasks/sync_github_access.py
@@ -65,7 +65,13 @@ def sync_repos_for_owner(
             ).delete(synchronize_session=False)
 
 
-@celery.task(max_retries=5, autoretry_for=(Exception,), acks_late=True, time_limit=60)
+@celery.task(
+    name="zeus.sync_github_access",
+    max_retries=5,
+    autoretry_for=(Exception,),
+    acks_late=True,
+    time_limit=60,
+)
 def sync_github_access(user_id: UUID):
     user = User.query.get(user_id)
     if not user:

--- a/zeus/utils/celery.py
+++ b/zeus/utils/celery.py
@@ -33,8 +33,22 @@ class Celery(object):
         task_postrun.connect(self._task_postrun)
         task_prerun.connect(self._task_prerun)
 
-    def task(self, *args, **kwargs):
-        return self.celery.task(*args, **kwargs)
+    def task(self, name=None, *args, **kwargs):
+        if not name:
+            raise ValueError(
+                "Tasks must have a name specified. Recommend: zeus.[task-name]"
+            )
+        return self.celery.task(name=name, *args, **kwargs)
+
+    @property
+    def tasks(self):
+        return self.celery.tasks
+
+    def call(self, task_name, *args, **kwargs):
+        return self.celery.tasks[task_name](*args, **kwargs)
+
+    def delay(self, task_name, *args, **kwargs):
+        return self.celery.tasks[task_name].delay(*args, **kwargs)
 
     def get_celery_app(self):
         return self.celery

--- a/zeus/vcs/client.py
+++ b/zeus/vcs/client.py
@@ -7,6 +7,8 @@ from typing import List, Optional, Union
 from uuid import UUID
 
 from zeus import auth
+from zeus.config import celery
+from zeus.constants import DeactivationReason
 from zeus.exceptions import ApiError, UnknownRevision
 
 
@@ -63,10 +65,10 @@ class VcsServerClient(object):
             # XXX(dcramer): this feels a bit hacky, and ideally would be handled
             # in the vcs implementation
             if data.get("error") == "invalid_pubkey" and params:
-                from zeus.tasks import deactivate_repo, DeactivationReason
-
-                deactivate_repo.delay(
-                    params["repo_id"], DeactivationReason.invalid_pubkey
+                celery.delay(
+                    "deactivate_repo",
+                    params["repo_id"],
+                    DeactivationReason.invalid_pubkey,
                 )
 
             if data.get("error") == "invalid_ref":


### PR DESCRIPTION
This moves the `task.delay` abstraction into `zeus.config.celery`, ensuring
we can centrally control the behavior. Additionally it adds a `call` method
for doing the synchronous calls.

It also renames some tasks, which may result in lost jobs, but the important
ones should retry.

bors r+