### PR TITLE
fix: Set job.date_updated on every PUT

### DIFF
--- a/tests/zeus/api/resources/test_build_jobs.py
+++ b/tests/zeus/api/resources/test_build_jobs.py
@@ -48,6 +48,9 @@ def test_build_job_create(
     assert job.result == Result.unknown
     assert job.build_id == default_build.id
     assert job.repository_id == default_repo.id
+    assert job.date_updated
+    assert not job.date_started
+    assert not job.date_finished
 
 
 def test_build_job_create_existing_entity(

--- a/zeus/api/resources/build_jobs.py
+++ b/zeus/api/resources/build_jobs.py
@@ -34,6 +34,7 @@ class BuildJobsResource(BaseBuildResource):
         if job.status != Status.queued and not job.date_started:
             job.date_started = timezone.now()
 
+        job.date_updated = timezone.now()
         db.session.add(job)
 
         try:


### PR DESCRIPTION
This fixes a race condition between cleanup_jobs and newly enqueued jobs (which haven't started).

bors r+